### PR TITLE
Remove some needless match statements

### DIFF
--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -16,17 +16,10 @@ async fn main() -> Result<(), std::io::Error> {
     let app_name = env::var("APP_NAME").expect("APP_NAME must be set");
 
     // Configuring DB connection
-    let mut client_options = match ClientOptions::parse(&conn_str).await {
-        Ok(c) => c,
-        Err(e) => panic!("Client Options Failed: {}", e),
-    };
-
+    let mut client_options = ClientOptions::parse(&conn_str).await.unwrap();
     client_options.app_name = Some(app_name);
 
-    let client = match Client::with_options(client_options) {
-        Ok(c) => c,
-        Err(e) => panic!("Client Creation Failed: {}", e),
-    };
+    let client = Client::with_options(client_options).unwrap();
 
     let engine = State {
         client: Arc::new(client),


### PR DESCRIPTION
Remove some match statements where we panic if there's an error anyway.
panic! will show the error message and where it came from anyway, so we
can just go to the line number to see what panicked.