### PR TITLE
Reorder imports and remove super::*

### DIFF
--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -1,8 +1,10 @@
 #[macro_use]
 extern crate serde_json;
+
 use async_std::sync::Arc;
 use mongodb::Client;
-pub mod models;
+
+mod models;
 pub mod routes;
 
 #[derive(Clone, Debug)]

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -1,9 +1,10 @@
+use std::env;
+
 use async_std::sync::Arc;
 use dotenv::dotenv;
 use http_types::headers::HeaderValue;
 use mongodb::options::{ClientOptions, Credential, StreamAddress};
 use mongodb::Client;
-use std::env;
 use tide::security::{CorsMiddleware, Origin};
 
 use dodona::routes;

--- a/api-server/src/models/model.rs
+++ b/api-server/src/models/model.rs
@@ -1,17 +1,14 @@
-use anyhow::{Error, Result};
-use async_trait::async_trait;
-use mongodb::bson::oid::ObjectId;
-use mongodb::bson::{doc, from_bson, to_bson};
-use mongodb::bson::{Bson, Document};
-use mongodb::options;
-use mongodb::results::DeleteResult;
-use mongodb::{Collection, Database};
-use serde::{de::DeserializeOwned, Serialize};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use anyhow::{Error, Result};
+use async_trait::async_trait;
 use futures::stream::Stream;
-use mongodb::Cursor;
+use mongodb::bson::oid::ObjectId;
+use mongodb::bson::{doc, from_bson, to_bson, Bson, Document};
+use mongodb::results::DeleteResult;
+use mongodb::{options, Collection, Cursor, Database};
+use serde::{de::DeserializeOwned, Serialize};
 
 /// A cursor of model documents.
 pub struct ModelCursor<T> {

--- a/api-server/src/models/users.rs
+++ b/api-server/src/models/users.rs
@@ -1,6 +1,7 @@
-use super::*;
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
+
+use crate::models::model;
 
 // Define a model. Simple as deriving a few traits.
 #[derive(Debug, Serialize, Deserialize)]

--- a/api-server/src/routes/mod.rs
+++ b/api-server/src/routes/mod.rs
@@ -1,5 +1,6 @@
-use super::*;
 use tide::{http::mime, Request, Response};
+
+use crate::State;
 
 pub mod users;
 

--- a/api-server/src/routes/users.rs
+++ b/api-server/src/routes/users.rs
@@ -1,11 +1,11 @@
-use super::*;
-use crate::models::model::Model;
-use crate::models::users::User;
 use async_std::stream::StreamExt;
 use mongodb::bson::{doc, document::Document, oid::ObjectId};
-use serde_json::value::Map;
-use tide;
+use tide::http::mime;
 use tide::{Request, Response};
+
+use crate::models::model::Model;
+use crate::models::users::User;
+use crate::State;
 
 /// This route will take in a user ID in the request and
 /// will return the information for that user
@@ -57,7 +57,7 @@ pub async fn edit(mut req: Request<State>) -> tide::Result {
     println!("User: {:?}", &user);
     let user_id = user.id().unwrap();
     Ok(Response::builder(200)
-        .body(json!(doc!{"user_id": user_id.to_string()}))
+        .body(json!(doc! {"user_id": user_id.to_string()}))
         .content_type(mime::JSON)
         .build())
 }


### PR DESCRIPTION
Reorder the imports for each file so that it is as follows:

- Standard library imports (`std::env`, `std::collections::HashMap`)
- External crate imports (`mongodb::Client`, `tide::http::mime`)
- Internal crate imports (`crate::State`, `crate::models::model`)

Remove the usage of `super::*` for 2 reasons:

- Wildcard import, hard to know what it is pulling in
- Requires you to know where in the module tree you are

Using the full path of the element you are importing should be
preferred, such as `crate::State`, as this is agnostic of the current
position and clearly describes everything that you are importing.