### PR TITLE
Fix a clippy lint

### DIFF
--- a/api-server/src/routes/users.rs
+++ b/api-server/src/routes/users.rs
@@ -194,32 +194,29 @@ pub async fn login(mut req: Request<State>) -> tide::Result {
         .await?
         .map(|doc| mongodb::bson::de::from_document::<User>(doc).unwrap());
 
-    match user {
-        Some(user) => {
-            let peppered = format!("{}{}", password, pepper);
-            let verified = pbkdf2::pbkdf2_check(&peppered, &user.password).is_ok();
+    if let Some(user) = user {
+        let peppered = format!("{}{}", password, pepper);
+        let verified = pbkdf2::pbkdf2_check(&peppered, &user.password).is_ok();
 
-            if verified {
-                println!("Logged in: {:?}", user);
-                Ok(Response::builder(200)
-                    .body(json!(doc! {"token": user.id.unwrap().to_string()}))
-                    .content_type(mime::JSON)
-                    .build())
-            } else {
-                println!("Failed login: wrong password");
-                Ok(Response::builder(200)
-                    .body(json!(doc! {"token": "null"}))
-                    .content_type(mime::JSON)
-                    .build())
-            }
-        }
-        None => {
-            println!("Failed login: wrong email");
+        if verified {
+            println!("Logged in: {:?}", user);
+            Ok(Response::builder(200)
+                .body(json!(doc! {"token": user.id.unwrap().to_string()}))
+                .content_type(mime::JSON)
+                .build())
+        } else {
+            println!("Failed login: wrong password");
             Ok(Response::builder(200)
                 .body(json!(doc! {"token": "null"}))
                 .content_type(mime::JSON)
                 .build())
         }
+    } else {
+        println!("Failed login: wrong email");
+        Ok(Response::builder(200)
+            .body(json!(doc! {"token": "null"}))
+            .content_type(mime::JSON)
+            .build())
     }
 }
 


### PR DESCRIPTION
Fix a clippy lint to reduce rightward drift in the API. This changes
nothing about the execution, just makes it slightly easier to read.

Found using `#![warn(clippy::all)]` in `src/lib.rs`.