### PR TITLE
Add documentation to everything

### DIFF
--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -1,3 +1,11 @@
+//! Contains the API server for the Sybl website.
+//!
+//! Manages the backend with a Mongo database and responds to frontend requests for data.
+
+#![warn(rust_2018_idioms)]
+#![warn(missing_debug_implementations)]
+#![warn(missing_docs)]
+
 #[macro_use]
 extern crate serde;
 #[macro_use]
@@ -15,13 +23,34 @@ pub mod config;
 pub mod models;
 pub mod routes;
 
+/// Defines the state for each request to access.
 #[derive(Clone, Debug)]
 pub struct State {
+    /// An instance of the MongoDB client
     pub client: Arc<Client>,
+    /// The name of the database to access
     pub db_name: Arc<String>,
+    /// The pepper to use when hashing
     pub pepper: Arc<String>,
 }
 
+/// Builds the Tide server.
+///
+/// Creates a new Tide server instance and adds the API routes to it, along with setting up the
+/// [`State`] that each request has access to. This allows the server to be set up externally more
+/// easily, by simply building it and then calling the `listen` method.
+///
+/// # Examples
+///
+/// ```no_run
+/// #[async_std::main]
+/// async fn main() -> std::io::Result<()> {
+///     let server = dodona::build_server().await;
+///     server.listen("localhost:3000").await?;
+///
+///     Ok(())
+/// }
+/// ```
 pub async fn build_server() -> tide::Server<State> {
     let conn_str = env::var("CONN_STR").expect("CONN_STR must be set");
     let app_name = env::var("APP_NAME").expect("APP_NAME must be set");
@@ -43,7 +72,6 @@ pub async fn build_server() -> tide::Server<State> {
 
     // Setting up routes
     let mut core_api = app.at("/api");
-    core_api.at("/").get(routes::index);
 
     let mut user_api = core_api.at("/users");
     user_api.at("/:user_id").get(routes::users::get);
@@ -76,6 +104,10 @@ pub async fn build_server() -> tide::Server<State> {
     app
 }
 
+/// Loads the configuration for a given environment into environment variables.
+///
+/// Given the current environment, loads the configuration file and resolves it based on the given
+/// environment, before populating the environment variables with the values contained.
 pub fn load_config(environment: config::Environment) {
     let config = config::ConfigFile::from_file("config.toml");
     let resolved = config.resolve(environment);

--- a/api-server/src/models/mod.rs
+++ b/api-server/src/models/mod.rs
@@ -1,2 +1,4 @@
+//! Defines the data models used in the MongoDB instance.
+
 pub mod projects;
 pub mod users;

--- a/api-server/src/models/projects.rs
+++ b/api-server/src/models/projects.rs
@@ -1,13 +1,19 @@
+//! Defines the structure of projects in the MongoDB instance.
+
 use mongodb::bson;
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
 
-// Define a model. Simple as deriving a few traits.
+/// Defines the information that should be stored with a project in the database.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Project {
+    /// The unique identifier for the project
     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<ObjectId>,
+    /// The name of the project
     pub name: String,
+    /// The date and time that the project was created
     pub date_created: bson::DateTime,
+    /// The identifier of the user who created the project
     pub user_id: Option<ObjectId>,
 }

--- a/api-server/src/models/users.rs
+++ b/api-server/src/models/users.rs
@@ -1,13 +1,20 @@
+//! Defines the structure of users in the MongoDB instance.
+
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
 
-// Define a model. Simple as deriving a few traits.
+/// Defines the information that should be stored with a user in the database.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct User {
+    /// The unique identifier for the user
     #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
     pub id: Option<ObjectId>,
+    /// The user's email
     pub email: String,
+    /// The peppered and hashed version of the user's password
     pub password: String,
+    /// The user's first name
     pub first_name: String,
+    /// The user's last name
     pub last_name: String,
 }

--- a/api-server/src/routes/mod.rs
+++ b/api-server/src/routes/mod.rs
@@ -1,24 +1,43 @@
-use tide::http::mime;
-use tide::{Request, Response};
+//! Defines the routes for the API server.
 
-use crate::State;
+use tide::{http::mime, Response};
 
 pub mod projects;
 pub mod users;
 
+/// Builds a [`Response`] with a 200 OK and JSON payload.
+///
+/// Defines a helper function that can be used to quickly build a JSON payload response to a user
+/// request. As many API functions take and return JSON, this reduces repetition when the route has
+/// been processed correctly.
+///
+/// # Examples
+///
+/// ```
+/// use serde::Serialize;
+/// use dodona::routes::response_from_json;
+///
+/// #[derive(Serialize)]
+/// struct Payload {
+///     name: String,
+///     age: u32,
+/// }
+///
+/// let payload = Payload { name: String::from("Freddie"), age: 22 };
+/// let mut response = response_from_json(payload);
+///
+/// assert_eq!(response.status(), tide::StatusCode::Ok);
+/// assert_eq!(response.content_type(), Some(tide::http::mime::JSON));
+///
+/// let body = async_std::task::block_on(response.take_body().into_string());
+/// let expected = String::from(r#"{"name":"Freddie","age":22}"#);
+///
+/// assert!(body.is_ok());
+/// assert_eq!(body.unwrap(), expected);
+/// ```
 pub fn response_from_json<B: serde::Serialize>(body: B) -> Response {
     Response::builder(200)
         .body(json!(body))
         .content_type(mime::JSON)
         .build()
-}
-
-pub async fn index(_req: Request<State>) -> tide::Result<impl Into<Response>> {
-    Ok(Response::builder(200)
-        .body(json!({"name": "Freddie", "age": 22}))
-        .content_type(mime::JSON))
-}
-
-pub async fn hello(_req: Request<State>) -> tide::Result<impl Into<Response>> {
-    Ok("Hey from Dodona!")
 }

--- a/api-server/src/routes/projects.rs
+++ b/api-server/src/routes/projects.rs
@@ -1,3 +1,5 @@
+//! Defines the routes specific to project operations.
+
 use async_std::stream::StreamExt;
 use mongodb::bson::{doc, document::Document, oid::ObjectId};
 use tide::{Request, Response};
@@ -6,8 +8,10 @@ use crate::models::projects::Project;
 use crate::routes::response_from_json;
 use crate::State;
 
-/// route will return all projects in database
-/// mainly for testing purposes
+/// Gets all the projects from the database.
+///
+/// Defines a catch-all testing route that will pull all available projects and their information
+/// from the Mongo database.
 pub async fn get_all(req: Request<State>) -> tide::Result {
     let database = req.state().client.database("sybl");
     let projects = database.collection("projects");
@@ -18,8 +22,10 @@ pub async fn get_all(req: Request<State>) -> tide::Result {
     Ok(response_from_json(documents.unwrap()))
 }
 
-/// route will return a single project with the id
-/// matching the request
+/// Finds a project in the database given an identifier.
+///
+/// Given a project identifier, finds the project in the database and returns it as a JSON object.
+/// If the project does not exist, returns a 404 response code.
 pub async fn get_project(req: Request<State>) -> tide::Result {
     let database = req.state().client.database("sybl");
     let projects = database.collection("projects");
@@ -37,7 +43,10 @@ pub async fn get_project(req: Request<State>) -> tide::Result {
     Ok(response_from_json(proj))
 }
 
-/// Get all projects related to a user
+/// Finds all the projects related to a given user.
+///
+/// Given a user identifier, finds all the projects in the database that the user owns. If the user
+/// doesn't exist or an invalid identifier is given, returns a 404 response.
 pub async fn get_user_projects(req: Request<State>) -> tide::Result {
     let database = req.state().client.database("sybl");
     let projects = database.collection("projects");

--- a/api-server/src/routes/users.rs
+++ b/api-server/src/routes/users.rs
@@ -1,3 +1,5 @@
+//! Defines the routes specific to user operations.
+
 use ammonia::clean_text;
 use async_std::stream::StreamExt;
 use mongodb::bson::{doc, document::Document, oid::ObjectId};
@@ -9,8 +11,10 @@ use crate::State;
 
 const PBKDF2_ROUNDS: u32 = 100_000;
 
-/// This route will take in a user ID in the request and
-/// will return the information for that user
+/// Gets a user given their database identifier.
+///
+/// Given a user identifier, finds the user in the database and returns them as a JSON object. If
+/// the user does not exist, the handler will panic.
 pub async fn get(req: Request<State>) -> tide::Result {
     let database = req.state().client.database("sybl");
     let users = database.collection("users");
@@ -26,9 +30,11 @@ pub async fn get(req: Request<State>) -> tide::Result {
     Ok(response_from_json(json))
 }
 
-/// More general version of get. Allows filter to be passed to
-/// the find. This will return a JSON object containing multiple
-/// users which fulfill the filter.
+/// Gets all users who match a filter.
+///
+/// Given a filter query, finds all users who match the filter and returns them as a JSON array of
+/// objects. For example, given `{"first_name", "John"}`, finds all the users with the first name
+/// John.
 pub async fn filter(mut req: Request<State>) -> tide::Result {
     let database = req.state().client.database("sybl");
     let users = database.collection("users");
@@ -42,15 +48,11 @@ pub async fn filter(mut req: Request<State>) -> tide::Result {
     Ok(response_from_json(documents.unwrap()))
 }
 
-/// New route which will allow the frontend to send an email and password
-/// which create a new user. This will return the token for the new user.
-/// For this, a JSON object must be sent to the route, e.g:
-/// {
-///     "email": "email@email.com",
-///     "password": "password"
-/// }
+/// Creates a new user given the form information.
 ///
-/// This will return the user token
+/// Given an email, password, first name and last name, peppers their password and hashes it. This
+/// then gets stored in the Mongo database with a randomly generated user identifier. If the user's
+/// email already exists, the route will not register any user.
 pub async fn new(mut req: Request<State>) -> tide::Result {
     let doc: Document = req.body_json().await?;
     log::debug!("Document received: {:?}", &doc);
@@ -102,16 +104,10 @@ pub async fn new(mut req: Request<State>) -> tide::Result {
     Ok(response_from_json(doc! {"token": id.to_string()}))
 }
 
-/// Pass a JSON object with the ObjectId for the user
-/// which is being edited and the attributes which are being
-/// changed. This should look like:
-/// {
-///     "id": "TOKEN"
-///     "email": "email@email.com",
-///     "password": "password"
-/// }
+/// Edits a user in the database and updates their information.
 ///
-/// This will return the status of the transaction
+/// Given a user identifier, finds the user in the database and updates their information based on
+/// the JSON provided, returning a message based on whether it was updated.
 pub async fn edit(mut req: Request<State>) -> tide::Result {
     let state = req.state();
     let database = state.client.database("sybl");
@@ -141,16 +137,11 @@ pub async fn edit(mut req: Request<State>) -> tide::Result {
     Ok(response_from_json(doc! {"status": "changed"}))
 }
 
-/// Login route which will allow the frontend to send an email and password
-/// which will be checked against the database. If there is a user with those
-/// credentials then a token will be returned. Otherwise "null" will be returned
-/// For this, a JSON object must be sent to the route
-/// {
-///     "email": "email@email.com",
-///     "password": "password"
-/// }
+/// Verifies a user's password against the one in the database.
 ///
-/// This will return the user token
+/// Given an email and password, finds the user in the database and checks that the two hashes
+/// match. If they don't, or the user does not exist, it will not authenticate them and send back a
+/// null token.
 pub async fn login(mut req: Request<State>) -> tide::Result {
     let doc: Document = req.body_json().await?;
 
@@ -189,8 +180,9 @@ pub async fn login(mut req: Request<State>) -> tide::Result {
     }
 }
 
-/// Delete method. Pass ID as part of JSON object and the corressponding user
-/// will be deleted from the Database.
+/// Deletes a user from the database.
+///
+/// Given a user identifier, deletes the related user from the database if they exist.
 pub async fn delete(mut req: Request<State>) -> tide::Result {
     let doc: Document = req.body_json().await?;
 


### PR DESCRIPTION
Add documentation to every publically accessible method that
`#![warn(missing_docs)]` complains about. Documentation can be viewed by
running `cargo doc --open` and should allow for easier development in
the future.

Add doctests, which can be run individually with `cargo test --doc` and
allow examples to be shown in the browser.

Enable some additional compiler warnings for missing documentation,
debug implementations and Rust 2018 idioms (although this is unlikely to
be needed).

Remove some unused methods that were previously used for testing.

In the future, documentation can be added to API routes to show the
expected input and output formats.