### PR TITLE
Add pbkdf2_iterations to the config

### DIFF
--- a/api-server/src/config.rs
+++ b/api-server/src/config.rs
@@ -18,14 +18,16 @@ pub enum Environment {
 }
 
 /// Defines what variables can be configured in the file and their types.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Default, Deserialize)]
 pub struct Config {
     /// The name of the app to use for MongoDB
     pub app_name: Option<String>,
     /// The connection URI for the Mongo database instance
     pub conn_str: Option<String>,
-    /// The pepper to use for encryption purposes
+    /// The pepper to use for hashing purposes
     pub pepper: Option<String>,
+    /// The number of iterations to use for hashing purposes
+    pub pbkdf2_iterations: Option<u32>,
 }
 
 impl Config {
@@ -43,19 +45,26 @@ impl Config {
     ///     app_name: Some("app_name".into()),
     ///     conn_str: Some("localhost".into()),
     ///     pepper: None,
+    ///     pbkdf2_iterations: None,
     /// };
     ///
     /// let specific = Config {
     ///     app_name: None,
     ///     conn_str: Some("mongo_uri".into()),
     ///     pepper: Some("pepper".into()),
+    ///     pbkdf2_iterations: None,
     /// };
     ///
     /// config.or(specific);
     ///
-    /// assert_eq!(config.app_name, Some("app_name".into()));
-    /// assert_eq!(config.conn_str, Some("mongo_uri".into()));
-    /// assert_eq!(config.pepper, Some("pepper".into()));
+    /// let expected = Config {
+    ///     app_name: Some("app_name".into()),
+    ///     conn_str: Some("mongo_uri".into()),
+    ///     pepper: Some("pepper".into()),
+    ///     pbkdf2_iterations: None,
+    /// };
+    ///
+    /// assert_eq!(config, expected);
     /// ```
     pub fn or(&mut self, config: Config) {
         if config.app_name.is_some() {
@@ -68,6 +77,10 @@ impl Config {
 
         if config.pepper.is_some() {
             self.pepper = config.pepper;
+        }
+
+        if config.pbkdf2_iterations.is_some() {
+            self.pbkdf2_iterations = config.pbkdf2_iterations;
         }
     }
 
@@ -82,6 +95,7 @@ impl Config {
     ///     app_name: Some("app_name".into()),
     ///     conn_str: Some("localhost".into()),
     ///     pepper: None,
+    ///     pbkdf2_iterations: None,
     /// };
     ///
     /// config.populate_environment();
@@ -90,6 +104,7 @@ impl Config {
     /// assert_eq!(std::env::var("CONN_STR"), Ok("localhost".into()));
     ///
     /// assert!(std::env::var("PEPPER").is_err());
+    /// assert!(std::env::var("PBKDF2_ITERATIONS").is_err());
     /// ```
     pub fn populate_environment(&self) {
         if let Some(app_name) = &self.app_name {
@@ -102,6 +117,10 @@ impl Config {
 
         if let Some(pepper) = &self.pepper {
             std::env::set_var("PEPPER", pepper);
+        }
+
+        if let Some(pbkdf2_iterations) = &self.pbkdf2_iterations {
+            std::env::set_var("PBKDF2_ITERATIONS", pbkdf2_iterations.to_string());
         }
     }
 }
@@ -180,19 +199,28 @@ impl ConfigFile {
     /// app_name = "Dodona"
     /// pepper = "pepper"
     ///
+    /// [production]
+    /// pbkdf2_iterations = 10000
+    ///
     /// [development]
     /// pepper = "dev_pepper"
     ///
     /// [testing]
     /// conn_str = "localhost"
+    ///
     /// "#;
     ///
     /// let config_file = ConfigFile::from_str(config);
     /// let development = config_file.resolve(Environment::Development);
     ///
-    /// assert_eq!(development.app_name, Some("Dodona".into()));
-    /// assert_eq!(development.conn_str, None);
-    /// assert_eq!(development.pepper, Some("dev_pepper".into()));
+    /// let expected = Config {
+    ///     app_name: Some("Dodona".into()),
+    ///     conn_str: None,
+    ///     pepper: Some("dev_pepper".into()),
+    ///     pbkdf2_iterations: None,
+    /// };
+    ///
+    /// assert_eq!(development, expected);
     /// ```
     pub fn resolve(self, environment: Environment) -> Config {
         // Start with defaults

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -12,6 +12,7 @@ extern crate serde;
 extern crate serde_json;
 
 use std::env;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use http_types::headers::HeaderValue;
@@ -32,6 +33,8 @@ pub struct State {
     pub db_name: Arc<String>,
     /// The pepper to use when hashing
     pub pepper: Arc<String>,
+    /// The number of iterations to use for hashing
+    pub pbkdf2_iterations: u32,
 }
 
 /// Builds the Tide server.
@@ -55,6 +58,7 @@ pub async fn build_server() -> tide::Server<State> {
     let conn_str = env::var("CONN_STR").expect("CONN_STR must be set");
     let app_name = env::var("APP_NAME").expect("APP_NAME must be set");
     let pepper = env::var("PEPPER").expect("PEPPER must be set");
+    let pbkdf2_iterations = env::var("PBKDF2_ITERATIONS").expect("PBKDF2_ITERATIONS must be set");
 
     // Configuring DB connection
     let mut client_options = ClientOptions::parse(&conn_str).await.unwrap();
@@ -66,6 +70,7 @@ pub async fn build_server() -> tide::Server<State> {
         client: Arc::new(client),
         db_name: Arc::new(String::from("sybl")),
         pepper: Arc::new(pepper),
+        pbkdf2_iterations: u32::from_str(&pbkdf2_iterations).unwrap(),
     };
 
     let mut app = tide::with_state(engine);

--- a/api-server/src/routes/users.rs
+++ b/api-server/src/routes/users.rs
@@ -9,8 +9,6 @@ use crate::models::users::User;
 use crate::routes::response_from_json;
 use crate::State;
 
-const PBKDF2_ROUNDS: u32 = 100_000;
-
 /// Gets a user given their database identifier.
 ///
 /// Given a user identifier, finds the user in the database and returns them as a JSON object. If
@@ -83,11 +81,8 @@ pub async fn new(mut req: Request<State>) -> tide::Result {
     log::info!("User does not exist, registering them now");
 
     let peppered = format!("{}{}", &password, &pepper);
+    let pbkdf2_hash = pbkdf2::pbkdf2_simple(&peppered, state.pbkdf2_iterations).unwrap();
 
-    let pbkdf2_hash = pbkdf2::pbkdf2_simple(&peppered, PBKDF2_ROUNDS).unwrap();
-    let verified = pbkdf2::pbkdf2_check(&peppered, &pbkdf2_hash).is_ok();
-
-    log::info!("Verified: {}", verified);
     log::info!("Hash: {:?}", pbkdf2_hash);
 
     let user = User {

--- a/api-server/tests/api.rs
+++ b/api-server/tests/api.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use bson::document::Document;
 use bson::oid::ObjectId;
 use serde::Deserialize;
@@ -53,7 +55,9 @@ fn initialise() {
 
             // Insert some test users
             let peppered = format!("password{}", std::env::var("PEPPER").unwrap());
-            let hash = pbkdf2::pbkdf2_simple(&peppered, 10_000).unwrap();
+            let pbkdf2_iterations =
+                u32::from_str(&std::env::var("PBKDF2_ITERATIONS").unwrap()).unwrap();
+            let hash = pbkdf2::pbkdf2_simple(&peppered, pbkdf2_iterations).unwrap();
 
             let matthew = bson::doc! {
                 "email": "matthewsmith@email.com",

--- a/api-server/tests/config.rs
+++ b/api-server/tests/config.rs
@@ -1,4 +1,6 @@
-use dodona::config::{ConfigFile, Environment};
+use std::str::FromStr;
+
+use dodona::config::{Config, ConfigFile, Environment};
 
 static TEST_CONFIG: &str = r#"
 [global]
@@ -14,33 +16,49 @@ pepper = "develop"
 
 [testing]
 conn_str = "localhost"
+pbkdf2_iterations = 1000
 "#;
 
 #[test]
 fn resolve_production_config() {
     let config = ConfigFile::from_str(TEST_CONFIG).resolve(Environment::Production);
 
-    assert_eq!(config.app_name, Some("Sybl".into()));
-    assert_eq!(config.conn_str, None);
-    assert_eq!(config.pepper, Some("prod".into()));
+    let expected = Config {
+        app_name: Some("Sybl".into()),
+        conn_str: None,
+        pepper: Some("prod".into()),
+        pbkdf2_iterations: None,
+    };
+
+    assert_eq!(config, expected);
 }
 
 #[test]
 fn resolve_development_config() {
     let config = ConfigFile::from_str(TEST_CONFIG).resolve(Environment::Development);
 
-    assert_eq!(config.app_name, Some("Dodona".into()));
-    assert_eq!(config.conn_str, None);
-    assert_eq!(config.pepper, Some("develop".into()));
+    let expected = Config {
+        app_name: Some("Dodona".into()),
+        conn_str: None,
+        pepper: Some("develop".into()),
+        pbkdf2_iterations: None,
+    };
+
+    assert_eq!(config, expected);
 }
 
 #[test]
 fn resolve_testing_config() {
     let config = ConfigFile::from_str(TEST_CONFIG).resolve(Environment::Testing);
 
-    assert_eq!(config.app_name, Some("Dodona".into()));
-    assert_eq!(config.conn_str, Some("localhost".into()));
-    assert_eq!(config.pepper, Some("default".into()));
+    let expected = Config {
+        app_name: Some("Dodona".into()),
+        conn_str: Some("localhost".into()),
+        pepper: Some("default".into()),
+        pbkdf2_iterations: Some(1000),
+    };
+
+    assert_eq!(config, expected);
 }
 
 #[test]
@@ -48,7 +66,19 @@ fn environment_variables_are_updated() {
     let config = ConfigFile::from_str(TEST_CONFIG).resolve(Environment::Testing);
     config.populate_environment();
 
-    assert_eq!(std::env::var("APP_NAME"), Ok("Dodona".into()));
-    assert_eq!(std::env::var("CONN_STR"), Ok("localhost".into()));
-    assert_eq!(std::env::var("PEPPER"), Ok("default".into()));
+    let app_name = std::env::var("APP_NAME").ok();
+    let conn_str = std::env::var("CONN_STR").ok();
+    let pepper = std::env::var("PEPPER").ok();
+    let pbkdf2_iterations = std::env::var("PBKDF2_ITERATIONS")
+        .ok()
+        .map(|x| u32::from_str(&x).unwrap());
+
+    let environment = Config {
+        app_name,
+        conn_str,
+        pepper,
+        pbkdf2_iterations,
+    };
+
+    assert_eq!(environment, config);
 }


### PR DESCRIPTION
Add the `pbkdf2_iterations` variable to the configuration file, allowing
people to use different iteration counts depending on the environment.
This allows less iterations for tests for example, so they can be
completed quicker.

Remove the checking of hashes when adding a new user, as this is really
just a sanity check and wasn't doing anything with the result.