### PR TITLE
Add and refactor test suite

### DIFF
--- a/api-server/tests/common.rs
+++ b/api-server/tests/common.rs
@@ -1,0 +1,118 @@
+use std::str::FromStr;
+
+use bson::document::Document;
+use bson::oid::ObjectId;
+use chrono::TimeZone;
+
+use dodona::config::Environment;
+
+// Hardcoded random identifiers for various tests
+pub static MAIN_USER_ID: &str = "5f8ca1a80065f27b0089e8b5";
+pub static CREATES_PROJECT_UID: &str = "5f8d7b4f0017036400d60cab";
+pub static NON_EXISTENT_USER_ID: &str = "5f8de85300eb281e00306b0b";
+
+pub static MAIN_PROJECT_ID: &str = "5f8ca1a80065f27c0089e8b5";
+pub static USERLESS_PROJECT_ID: &str = "5f8ca1a80065f27b0089e8b6";
+pub static NON_EXISTENT_PROJECT_ID: &str = "5f8ca1a80065f27b0089e8a5";
+
+/// Allows for the setup of the database prior to testing.
+static INIT: std::sync::Once = std::sync::Once::new();
+
+/// Defines the initialisation function for the tests.
+///
+/// This will clean the database and insert some basic data for testing purposes. It should be
+/// called at the beginning of every test function, and the `std::once::Once` will ensure that it
+/// is only ever called once.
+///
+/// As the database can be initialised before running, this allows tests to be run in any order
+/// provided they don't require the result of a previous test.
+pub fn initialise() {
+    INIT.call_once(|| {
+        async_std::task::block_on(async {
+            // Setup the environment variables
+            let config = dodona::config::ConfigFile::from_file("config.toml");
+            let resolved = config.resolve(Environment::Testing);
+            resolved.populate_environment();
+
+            // Connect to the database
+            let conn_str = std::env::var("CONN_STR").expect("CONN_STR must be set");
+            let client = mongodb::Client::with_uri_str(&conn_str).await.unwrap();
+            let database = client.database("sybl");
+            let collection_names = database.list_collection_names(None).await.unwrap();
+
+            // Delete all records currently in the database
+            for name in collection_names {
+                let collection = database.collection(&name);
+                collection.delete_many(Document::new(), None).await.unwrap();
+            }
+
+            // Insert some test data
+            insert_test_users(&database).await;
+            insert_test_projects(&database).await;
+        });
+    });
+}
+
+async fn insert_test_users(database: &mongodb::Database) {
+    let peppered = format!("password{}", std::env::var("PEPPER").unwrap());
+    let pbkdf2_iterations = u32::from_str(&std::env::var("PBKDF2_ITERATIONS").unwrap()).unwrap();
+    let hash = pbkdf2::pbkdf2_simple(&peppered, pbkdf2_iterations).unwrap();
+
+    let matthew = bson::doc! {
+        "_id": ObjectId::with_string(MAIN_USER_ID).unwrap(),
+        "email": "matthewsmith@email.com",
+        "password": hash,
+        "first_name": "Matthew",
+        "last_name": "Smith",
+    };
+    let delete = bson::doc! {
+        "email": "delete@me.com",
+        "password": "password",
+        "first_name": "Delete",
+        "last_name": "Me",
+    };
+    let creates_project = bson::doc! {
+        "_id": ObjectId::with_string(CREATES_PROJECT_UID).unwrap(),
+        "email": "creates@projects.com",
+        "password": "password",
+        "first_name": "Create",
+        "last_name": "Project",
+    };
+
+    let users = database.collection("users");
+    users.insert_one(matthew, None).await.unwrap();
+    users.insert_one(delete, None).await.unwrap();
+    users.insert_one(creates_project, None).await.unwrap();
+}
+
+async fn insert_test_projects(database: &mongodb::Database) {
+    let project = bson::doc! {
+        "_id": ObjectId::with_string(MAIN_PROJECT_ID).unwrap(),
+        "name": "Test Project",
+        "description": "Test Description",
+        "date_created": bson::Bson::DateTime(chrono::Utc.timestamp_millis(0)),
+        "user_id": ObjectId::with_string(MAIN_USER_ID).unwrap(),
+    };
+    let userless = bson::doc! {
+        "_id": ObjectId::with_string(USERLESS_PROJECT_ID).unwrap(),
+        "name": "Test Project",
+        "description": "Test Description",
+        "date_created": bson::Bson::DateTime(chrono::Utc.timestamp_millis(0)),
+        "user_id": ObjectId::with_string(NON_EXISTENT_USER_ID).unwrap(),
+    };
+
+    let projects = database.collection("projects");
+    projects.insert_one(project, None).await.unwrap();
+    projects.insert_one(userless, None).await.unwrap();
+}
+
+pub fn build_json_request(url: &str, body: &str) -> tide::http::Request {
+    let full_url = format!("localhost:{}", url);
+    let url = tide::http::Url::parse(&full_url).unwrap();
+    let mut req = tide::http::Request::new(tide::http::Method::Post, url);
+
+    req.set_body(body);
+    req.set_content_type(tide::http::mime::JSON);
+
+    req
+}

--- a/api-server/tests/projects.rs
+++ b/api-server/tests/projects.rs
@@ -1,0 +1,196 @@
+use tide::http::{Request, Response, Url};
+
+use dodona::models::projects::Project;
+
+mod common;
+
+#[async_std::test]
+async fn projects_can_be_fetched_for_a_user() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let formatted = format!("localhost:/api/projects/u/{}", common::MAIN_USER_ID);
+    let url = Url::parse(&formatted).unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let mut res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::Ok, res.status());
+    assert_eq!(Some(tide::http::mime::JSON), res.content_type());
+
+    let projects: Vec<Project> = res.body_json().await?;
+
+    assert_eq!(projects.len(), 1);
+
+    let found = &projects[0];
+
+    assert_eq!("Test Project", found.name);
+    assert_eq!("Test Description", found.description);
+    assert_eq!(0, found.date_created.timestamp_millis());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn projects_must_be_tied_to_a_user() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let formatted = format!("localhost:/api/projects/u/{}", common::NON_EXISTENT_USER_ID);
+    let url = Url::parse(&formatted).unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::NotFound, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn projects_cannot_be_found_for_invalid_user_ids() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let url = Url::parse("localhost:/api/projects/u/invalid").unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::NotFound, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn projects_can_be_fetched_by_identifier() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let formatted = format!("localhost:/api/projects/p/{}", common::MAIN_PROJECT_ID);
+    let url = Url::parse(&formatted).unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let mut res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::Ok, res.status());
+    assert_eq!(Some(tide::http::mime::JSON), res.content_type());
+
+    let project: Project = res.body_json().await?;
+
+    assert_eq!("Test Project", project.name);
+    assert_eq!("Test Description", project.description);
+    assert_eq!(0, project.date_created.timestamp_millis());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn non_existent_projects_are_not_found() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let formatted = format!(
+        "localhost:/api/projects/p/{}",
+        common::NON_EXISTENT_PROJECT_ID
+    );
+    let url = Url::parse(&formatted).unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::NotFound, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn projects_cannot_be_found_with_invalid_identifiers() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let url = Url::parse("localhost:/api/projects/p/invalid").unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::UnprocessableEntity, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn all_projects_can_be_fetched() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let url = Url::parse("localhost:/api/projects").unwrap();
+    let req = Request::new(tide::http::Method::Get, url);
+
+    let mut res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::Ok, res.status());
+    assert_eq!(Some(tide::http::mime::JSON), res.content_type());
+
+    let projects: Vec<Project> = res.body_json().await?;
+
+    assert_eq!(projects.len(), 2);
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn projects_cannot_be_created_for_non_existent_users() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let url_str = format!(
+        "localhost:/api/projects/u/{}/new",
+        common::USERLESS_PROJECT_ID
+    );
+    let url = Url::parse(&url_str).unwrap();
+    let req = Request::new(tide::http::Method::Post, url);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::UnprocessableEntity, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn projects_can_be_created() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let body = r#"{"name": "test", "description": "test"}"#;
+    let url = format!("/api/projects/u/{}/new", common::CREATES_PROJECT_UID);
+    let req = common::build_json_request(&url, body);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::Ok, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn datasets_can_be_added_to_projects() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let body = r#"{"content": "age,sex,location\n22,M,Leamington Spa"}"#;
+    let url = format!("/api/projects/p/{}/add", common::MAIN_PROJECT_ID);
+    let req = common::build_json_request(&url, body);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::Ok, res.status());
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn datasets_cannot_be_added_if_projects_do_not_exist() -> tide::Result<()> {
+    common::initialise();
+    let app = dodona::build_server().await;
+
+    let body = r#"{"content": "age,sex,location\n22,M,Leamington Spa"}"#;
+    let url = format!("/api/projects/p/{}/add", common::NON_EXISTENT_PROJECT_ID);
+    let req = common::build_json_request(&url, body);
+
+    let res: Response = app.respond(req).await?;
+    assert_eq!(tide::StatusCode::NotFound, res.status());
+
+    Ok(())
+}

--- a/api-server/tests/users.rs
+++ b/api-server/tests/users.rs
@@ -1,97 +1,18 @@
-use std::str::FromStr;
-
-use bson::document::Document;
-use bson::oid::ObjectId;
 use serde::Deserialize;
 use tide::http::Response;
 
-use dodona::config::Environment;
+use dodona::models::users::User;
+
+mod common;
 
 #[derive(Deserialize)]
 struct AuthResponse {
     pub token: String,
 }
 
-#[derive(Deserialize)]
-pub struct User {
-    #[serde(rename = "_id", skip_serializing_if = "Option::is_none")]
-    pub id: Option<ObjectId>,
-    pub email: String,
-    pub password: String,
-    pub first_name: String,
-    pub last_name: String,
-}
-
-/// Allows for the setup of the database prior to testing.
-static INIT: std::sync::Once = std::sync::Once::new();
-
-/// Defines the initialisation function for the tests.
-///
-/// This will clean the database and insert some basic data for testing purposes. It should be
-/// called at the beginning of every test function, and the `std::once::Once` will ensure that it
-/// is only ever called once.
-///
-/// As the database can be initialised before running, this allows tests to be run in any order
-/// provided they don't require the result of a previous test.
-fn initialise() {
-    INIT.call_once(|| {
-        async_std::task::block_on(async {
-            // Setup the environment variables
-            let config = dodona::config::ConfigFile::from_file("config.toml");
-            let resolved = config.resolve(Environment::Testing);
-            resolved.populate_environment();
-
-            // Connect to the database
-            let conn_str = std::env::var("CONN_STR").expect("CONN_STR must be set");
-            let client = mongodb::Client::with_uri_str(&conn_str).await.unwrap();
-            let database = client.database("sybl");
-            let collection_names = database.list_collection_names(None).await.unwrap();
-
-            // Delete all records currently in the database
-            for name in collection_names {
-                let collection = database.collection(&name);
-                collection.delete_many(Document::new(), None).await.unwrap();
-            }
-
-            // Insert some test users
-            let peppered = format!("password{}", std::env::var("PEPPER").unwrap());
-            let pbkdf2_iterations =
-                u32::from_str(&std::env::var("PBKDF2_ITERATIONS").unwrap()).unwrap();
-            let hash = pbkdf2::pbkdf2_simple(&peppered, pbkdf2_iterations).unwrap();
-
-            let matthew = bson::doc! {
-                "email": "matthewsmith@email.com",
-                "password": hash,
-                "first_name": "Matthew",
-                "last_name": "Smith",
-            };
-            let delete = bson::doc! {
-                "email": "delete@me.com",
-                "password": "password",
-                "first_name": "Delete",
-                "last_name": "Me",
-            };
-
-            let users = database.collection("users");
-            users.insert_one(matthew, None).await.unwrap();
-            users.insert_one(delete, None).await.unwrap();
-        });
-    });
-}
-
-fn build_json_request(url: &str, body: &str) -> tide::http::Request {
-    let url = tide::http::Url::parse(url).unwrap();
-    let mut req = tide::http::Request::new(tide::http::Method::Post, url);
-
-    req.set_body(body);
-    req.set_content_type(tide::http::mime::JSON);
-
-    req
-}
-
 #[async_std::test]
 async fn users_can_register() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"
@@ -101,7 +22,7 @@ async fn users_can_register() -> tide::Result<()> {
         "firstName": "John",
         "lastName": "Smith"
     }"#;
-    let req = build_json_request("localhost:/api/users/new", body);
+    let req = common::build_json_request("/api/users/new", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -115,7 +36,7 @@ async fn users_can_register() -> tide::Result<()> {
 
 #[async_std::test]
 async fn users_cannot_register_twice() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"
@@ -125,7 +46,7 @@ async fn users_cannot_register_twice() -> tide::Result<()> {
         "firstName": "Matthew",
         "lastName": "Smith"
     }"#;
-    let req = build_json_request("localhost:/api/users/new", body);
+    let req = common::build_json_request("/api/users/new", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -139,14 +60,14 @@ async fn users_cannot_register_twice() -> tide::Result<()> {
 
 #[async_std::test]
 async fn users_can_login() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"{
         "email": "matthewsmith@email.com",
         "password": "password"
     }"#;
-    let req = build_json_request("localhost:/api/users/login", body);
+    let req = common::build_json_request("/api/users/login", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -160,14 +81,14 @@ async fn users_can_login() -> tide::Result<()> {
 
 #[async_std::test]
 async fn users_cannot_login_without_correct_password() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"{
         "email": "matthewsmith@email.com",
         "password": "incorrect"
     }"#;
-    let req = build_json_request("localhost:/api/users/login", body);
+    let req = common::build_json_request("/api/users/login", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -182,14 +103,14 @@ async fn users_cannot_login_without_correct_password() -> tide::Result<()> {
 
 #[async_std::test]
 async fn users_cannot_login_without_correct_email() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"{
         "email": "mattsmith@email.com",
         "password": "password"
     }"#;
-    let req = build_json_request("localhost:/api/users/login", body);
+    let req = common::build_json_request("/api/users/login", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -204,11 +125,11 @@ async fn users_cannot_login_without_correct_email() -> tide::Result<()> {
 
 #[async_std::test]
 async fn filter_finds_given_user_and_no_others() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"{"email": "matthewsmith@email.com"}"#;
-    let req = build_json_request("localhost:/api/users/filter", body);
+    let req = common::build_json_request("/api/users/filter", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -228,11 +149,11 @@ async fn filter_finds_given_user_and_no_others() -> tide::Result<()> {
 
 #[async_std::test]
 async fn non_existent_users_are_not_found() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     let body = r#"{"email": "nonexistent@email.com"}"#;
-    let req = build_json_request("localhost:/api/users/filter", body);
+    let req = common::build_json_request("/api/users/filter", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -246,12 +167,12 @@ async fn non_existent_users_are_not_found() -> tide::Result<()> {
 
 #[async_std::test]
 async fn users_can_be_deleted() -> tide::Result<()> {
-    initialise();
+    common::initialise();
     let app = dodona::build_server().await;
 
     // Find the user
     let body = r#"{"email": "delete@me.com"}"#;
-    let req = build_json_request("localhost:/api/users/filter", body);
+    let req = common::build_json_request("/api/users/filter", body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());
@@ -262,7 +183,7 @@ async fn users_can_be_deleted() -> tide::Result<()> {
 
     // Delete the user
     let body = format!(r#"{{"id": "{}"}}"#, user.id.as_ref().unwrap().to_string());
-    let req = build_json_request("localhost:/api/users/delete", &body);
+    let req = common::build_json_request("/api/users/delete", &body);
 
     let mut res: Response = app.respond(req).await?;
     assert_eq!(tide::StatusCode::Ok, res.status());


### PR DESCRIPTION
Add tests for the project related routes, verifying that endpoints deal
with requests in the way we expect them.

Refactor the API testing suite into 3 files, one dealing with the core
of the testing system such as database setup, and the other 2 dealing
with users and projects respectively.

Add constants for the ObjectIds used for testing, as this makes them
seem less like magic numbers and allows the tests to be a little more
descriptive.

Remove the definitions of some structs as they were copied straight
from the server itself, instead choosing to import them.