### PR TITLE
Infer dataset column types on addition

### DIFF
--- a/api-server/Cargo.lock
+++ b/api-server/Cargo.lock
@@ -420,6 +420,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +624,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +732,7 @@ dependencies = [
  "bson",
  "bzip2",
  "chrono",
+ "csv",
  "futures",
  "http-types",
  "log",
@@ -1813,6 +1848,15 @@ name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "resolv-conf"

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4"
 toml = "0.5.7"
 chrono = "0.4"
 bzip2 = "0.4.1"
+csv = "1.1.3"
 
 [dependencies.mongodb]
 version = "1.1.0"

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -23,6 +23,7 @@ use tide::security::{CorsMiddleware, Origin};
 pub mod config;
 pub mod models;
 pub mod routes;
+pub mod utils;
 
 /// Defines the state for each request to access.
 #[derive(Clone, Debug)]

--- a/api-server/src/models/datasets.rs
+++ b/api-server/src/models/datasets.rs
@@ -1,9 +1,10 @@
 //! Defines the structure of datasets in the MongoDB instance.
 
+use std::collections::HashMap;
+
 use mongodb::bson;
 use mongodb::bson::oid::ObjectId;
 use mongodb::bson::Binary;
-use serde::{Deserialize, Serialize};
 
 /// Defines the information that should be stored with a dataset in the database.
 #[derive(Debug, Serialize, Deserialize)]
@@ -17,4 +18,6 @@ pub struct Dataset {
     pub date_created: bson::DateTime,
     /// Dataset binary stored in the db
     pub dataset: Option<Binary>,
+    /// The types of each column
+    pub column_types: HashMap<String, crate::utils::DatasetType>,
 }

--- a/api-server/src/utils.rs
+++ b/api-server/src/utils.rs
@@ -1,0 +1,104 @@
+//! Contains utility functions and types for CSV type inference.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+/// Represents the types that a CSV column could have.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum DatasetType {
+    /// String-like data, such as University.
+    Categorical,
+    /// Numerical data, such as Age.
+    Numerical,
+}
+
+impl DatasetType {
+    /// Infers the type of a string based on whether it is numerical or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dodona::utils::DatasetType;
+    /// assert_eq!(DatasetType::infer("Warwick"), DatasetType::Categorical);
+    /// assert_eq!(DatasetType::infer("22"), DatasetType::Numerical);
+    /// ```
+    pub fn infer(value: &str) -> Self {
+        match f64::from_str(value) {
+            Ok(_) => Self::Numerical,
+            Err(_) => Self::Categorical,
+        }
+    }
+}
+
+/// Infers the types of each column given a dataset.
+///
+/// Iterates through the rows of a dataset and decides the type of data in each column, which is
+/// one of [`DatasetType`]. The dataset is expected to be valid CSV data, with headers as the first
+/// row.
+///
+/// # Examples
+///
+/// ```
+/// # use std::collections::HashMap;
+/// # use dodona::utils::{DatasetType, infer_dataset_types};
+/// let dataset = r#"
+/// education,age
+/// Warwick,22
+/// Coventry,24
+/// "#;
+///
+/// let types = infer_dataset_types(dataset).unwrap();
+///
+/// let mut expected = HashMap::new();
+/// expected.insert(String::from("education"), DatasetType::Categorical);
+/// expected.insert(String::from("age"), DatasetType::Numerical);
+///
+/// assert_eq!(types, expected);
+/// ```
+pub fn infer_dataset_types(dataset: &str) -> csv::Result<HashMap<String, DatasetType>> {
+    // Get the headers
+    let mut reader = csv::Reader::from_reader(dataset.as_bytes());
+    let headers = reader.headers()?;
+
+    // Insert name and unknown type for each header
+    let mut types: HashMap<_, _> = headers
+        .into_iter()
+        .enumerate()
+        .map(|(i, h)| (i, (h.to_string(), DatasetType::Numerical)))
+        .collect();
+
+    // Ignore rows that fail to parse
+    let records = reader.records().filter_map(Result::ok);
+
+    // Update the types based on each row
+    for row in records {
+        for (i, v) in row.into_iter().enumerate() {
+            let inferred = DatasetType::infer(v);
+            let current = types.get_mut(&i).unwrap();
+
+            // Only overwrite if we are changing from Numerical
+            if let DatasetType::Numerical = current.1 {
+                current.1 = inferred;
+            }
+        }
+    }
+
+    // Pivot `types` to go from k => (n, t) to n => t
+    Ok(types.into_iter().map(|(_, v)| (v.0, v.1)).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn categorical_cannot_be_overwritten() {
+        let dataset = "age\n21\nTwenty\n20";
+        let types = infer_dataset_types(dataset).unwrap();
+
+        let mut expected = HashMap::new();
+        expected.insert(String::from("age"), DatasetType::Categorical);
+
+        assert_eq!(types, expected);
+    }
+}


### PR DESCRIPTION
When the user adds a dataset to their project, infer the types of each
column into either Numerical or Categorical. Store this in the database
so that in future it can be shown on the dashboard for users.

Dataset column inference works by attempting to parse each value as a
float, if this does not work then the column is categorised as
Categorical data. By default we assume all columns are numerical.