### PR TITLE
Fix the tests as bson was removed

### DIFF
--- a/api-server/tests/common.rs
+++ b/api-server/tests/common.rs
@@ -1,8 +1,7 @@
 use std::str::FromStr;
 
-use bson::document::Document;
-use bson::oid::ObjectId;
 use chrono::TimeZone;
+use mongodb::bson::{self, document::Document, oid::ObjectId};
 
 use dodona::config::Environment;
 


### PR DESCRIPTION
Fix the unit and integrations tests which broke after removing `bson` as
a direct dependency.