### PR TITLE
Ban running tests on Atlas

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ These mappings will then be placed in the environment variables when the server
 starts, allowing them to be used across machines and without hard-coding API
 keys.
 
+### Local MongoDB Instances for Testing
+
+If you want to run tests, you should use a local instance of MongoDB to avoid
+deleting production data or collections that other people are using at the same
+time. You can use `config.toml` to switch between a local instance and Atlas
+depending on the context using something such as:
+
+```
+[global]
+conn_str = <atlas_connection_string>
+
+[testing]
+conn_str = <local_connection_string>
+```
+
+Then, when you use `cargo run [--release]`, it will use the Atlas instance,
+whereas using `cargo test` will use your local instance instead.

--- a/api-server/tests/common.rs
+++ b/api-server/tests/common.rs
@@ -35,6 +35,13 @@ pub fn initialise() {
 
             // Connect to the database
             let conn_str = std::env::var("CONN_STR").expect("CONN_STR must be set");
+
+            // Ensure that we aren't using the Atlas instance
+            assert!(
+                !conn_str.starts_with("mongodb+srv"),
+                "Please setup a local MongoDB instance for running the tests"
+            );
+
             let client = mongodb::Client::with_uri_str(&conn_str).await.unwrap();
             let database = client.database("sybl");
             let collection_names = database.list_collection_names(None).await.unwrap();


### PR DESCRIPTION
Ban running unit tests on the Atlas instance, and add a section to the
README explaining `config.toml` slightly more and how to set up pointing
to a local instance only for testing purposes.