### PR TITLE
Fix the decompression for large files

### DIFF
--- a/api-server/src/utils.rs
+++ b/api-server/src/utils.rs
@@ -206,7 +206,7 @@ pub fn compress_data(data: &str) -> Result<Vec<u8>, std::io::Error> {
 /// ```
 pub fn decompress_data(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     let mut write_decompress = BzDecoder::new(vec![]);
-    write_decompress.write(data).unwrap();
+    write_decompress.write_all(data).unwrap();
     write_decompress.finish()
 }
 


### PR DESCRIPTION
Decompression was hanging for files larger than a couple lines (such as
1000 lines). This forces all the data to be written and signals that the
stream has finished at the end, which may have been causing issues
beforehand.