### PR TITLE
Log the config values on startup

### DIFF
--- a/api-server/src/config.rs
+++ b/api-server/src/config.rs
@@ -223,6 +223,8 @@ impl ConfigFile {
     /// assert_eq!(development, expected);
     /// ```
     pub fn resolve(self, environment: Environment) -> Config {
+        log::info!("Resolving config: {:?}", environment);
+
         // Start with defaults
         let mut config = Config::default();
 
@@ -242,6 +244,8 @@ impl ConfigFile {
         if let Some(subconfig) = subconfig {
             config.or(subconfig);
         }
+
+        log::info!("Config values: {:#?}", config);
 
         config
     }

--- a/api-server/src/main.rs
+++ b/api-server/src/main.rs
@@ -2,6 +2,8 @@ use dodona::config::Environment;
 
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+
     let environment = if cfg!(debug_assertions) {
         Environment::Development
     } else {
@@ -11,7 +13,6 @@ async fn main() -> Result<(), std::io::Error> {
     dodona::load_config(environment);
     let app = dodona::build_server().await;
 
-    tide::log::start();
     app.listen("0.0.0.0:3001").await?;
 
     Ok(())


### PR DESCRIPTION
Log the configuration that is being resolved alongside the configuration
values actually being used when the server starts up. This requires the
Tide logging to be initialised earlier, so that the `log` statements in
`src/config.rs` actually show up.