### PR TITLE
Generate API keys for DCL nodes

### DIFF
--- a/api-server/Cargo.lock
+++ b/api-server/Cargo.lock
@@ -739,6 +739,7 @@ dependencies = [
  "log",
  "mongodb",
  "pbkdf2 0.5.0",
+ "rand",
  "serde",
  "serde_json",
  "tide",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -22,6 +22,7 @@ toml = "0.5.7"
 chrono = "0.4"
 bzip2 = "0.4.1"
 csv = "1.1.3"
+rand = "0.7.3"
 
 [dependencies.mongodb]
 version = "1.1.0"

--- a/api-server/src/models/users.rs
+++ b/api-server/src/models/users.rs
@@ -17,4 +17,6 @@ pub struct User {
     pub first_name: String,
     /// The user's last name
     pub last_name: String,
+    /// The user's API key
+    pub api_key: String,
 }

--- a/api-server/tests/common.rs
+++ b/api-server/tests/common.rs
@@ -70,12 +70,14 @@ async fn insert_test_users(database: &mongodb::Database) {
         "password": hash,
         "first_name": "Matthew",
         "last_name": "Smith",
+        "api_key": "",
     };
     let delete = bson::doc! {
         "email": "delete@me.com",
         "password": "password",
         "first_name": "Delete",
         "last_name": "Me",
+        "api_key": "",
     };
     let creates_project = bson::doc! {
         "_id": ObjectId::with_string(CREATES_PROJECT_UID).unwrap(),
@@ -83,6 +85,7 @@ async fn insert_test_users(database: &mongodb::Database) {
         "password": "password",
         "first_name": "Create",
         "last_name": "Project",
+        "api_key": "",
     };
 
     let users = database.collection("users");


### PR DESCRIPTION
When a user signs up, generate them a random string of 32 characters to
act as an API key. This can then be displayed on the frontend in the
future to allow users to connect to the DCL and uniquely identify
themselves.

Fixes #72.