### PR TITLE
Remove some useless routes

### DIFF
--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -92,7 +92,6 @@ pub async fn build_server() -> tide::Server<State> {
     projects_api
         .at("/u/:user_id")
         .get(routes::projects::get_user_projects);
-    projects_api.at("/").get(routes::projects::get_all);
     projects_api
         .at("/p/:project_id")
         .get(routes::projects::get_project)
@@ -125,9 +124,6 @@ pub async fn build_server() -> tide::Server<State> {
         .allow_credentials(false);
 
     app.with(cors);
-
-    // Serving App
-    app.at("/").get(|_| async { Ok("Hello, world!") });
 
     app
 }

--- a/api-server/src/routes/projects.rs
+++ b/api-server/src/routes/projects.rs
@@ -15,20 +15,6 @@ use crate::routes::response_from_json;
 use crate::utils;
 use crate::State;
 
-/// Gets all the projects from the database.
-///
-/// Defines a catch-all testing route that will pull all available projects and their information
-/// from the Mongo database.
-pub async fn get_all(req: Request<State>) -> tide::Result {
-    let database = req.state().client.database("sybl");
-    let projects = database.collection("projects");
-
-    let cursor = projects.find(None, None).await?;
-    let documents: Result<Vec<Document>, mongodb::error::Error> = cursor.collect().await;
-
-    Ok(response_from_json(documents.unwrap()))
-}
-
 /// Finds a project in the database given an identifier.
 ///
 /// Given a project identifier, finds the project in the database and returns it as a JSON object.

--- a/api-server/tests/projects.rs
+++ b/api-server/tests/projects.rs
@@ -127,25 +127,6 @@ async fn projects_cannot_be_found_with_invalid_identifiers() -> tide::Result<()>
 }
 
 #[async_std::test]
-async fn all_projects_can_be_fetched() -> tide::Result<()> {
-    common::initialise();
-    let app = dodona::build_server().await;
-
-    let url = Url::parse("localhost:/api/projects").unwrap();
-    let req = Request::new(tide::http::Method::Get, url);
-
-    let mut res: Response = app.respond(req).await?;
-    assert_eq!(tide::StatusCode::Ok, res.status());
-    assert_eq!(Some(tide::http::mime::JSON), res.content_type());
-
-    let projects: Vec<Project> = res.body_json().await?;
-
-    assert_eq!(projects.len(), 5);
-
-    Ok(())
-}
-
-#[async_std::test]
 async fn projects_cannot_be_created_for_non_existent_users() -> tide::Result<()> {
     common::initialise();
     let app = dodona::build_server().await;


### PR DESCRIPTION
Remove the route to fetch all projects and the route at `/` which just
returns "Hello, world!". This also removes the test that fetches all the
projects, which was using a hardcoded value of between 2 and 5 projects.