### PR TITLE
Freddie/using test

### DIFF
--- a/backend/dcl/tests/comp_nodes.rs
+++ b/backend/dcl/tests/comp_nodes.rs
@@ -114,9 +114,9 @@ async fn test_dcn_using() {
             assert_ne!(oid1, oid2);
             assert!(nodepool.is_using(&oid2).await);
         } else {
-            assert!(false);
+            unreachable!();
         }
     } else {
-        assert!(false);
+        unreachable!();
     }
 }


### PR DESCRIPTION
Creates a test which does more extensive testing of the nodepool functionality for getting nodes to use for computation.