### PR TITLE
Infer train and predict data as one file upload

### DIFF
--- a/backend/models/src/datasets.rs
+++ b/backend/models/src/datasets.rs
@@ -1,7 +1,6 @@
 //! Defines the structure of datasets in the MongoDB instance.
 
-use mongodb::bson::oid::ObjectId;
-use mongodb::bson::Binary;
+use mongodb::bson::{self, oid::ObjectId, Binary};
 
 /// Defines the information that should be stored with a dataset in the database.
 #[derive(Debug, Serialize, Deserialize)]
@@ -11,6 +10,26 @@ pub struct Dataset {
     pub id: Option<ObjectId>,
     /// Unique identifier for the associated project
     pub project_id: Option<ObjectId>,
-    /// Dataset binary stored in the db
+    /// Dataset binary stored in the database
     pub dataset: Option<Binary>,
+    /// Dataset to be predicted by the model
+    pub predict: Option<Binary>,
+}
+
+impl Dataset {
+    /// Creates a new [`Dataset`] for a project with some data.
+    pub fn new(project_id: ObjectId, dataset: Vec<u8>, predict: Vec<u8>) -> Self {
+        Self {
+            id: None,
+            project_id: Some(project_id),
+            dataset: Some(Binary {
+                subtype: bson::spec::BinarySubtype::Generic,
+                bytes: dataset,
+            }),
+            predict: Some(Binary {
+                subtype: bson::spec::BinarySubtype::Generic,
+                bytes: predict,
+            }),
+        }
+    }
 }

--- a/backend/utils/src/lib.rs
+++ b/backend/utils/src/lib.rs
@@ -3,11 +3,12 @@
 #[macro_use]
 extern crate serde;
 
-use bzip2::write::{BzDecoder, BzEncoder};
-use bzip2::Compression;
 use std::collections::HashMap;
 use std::io::Write;
 use std::str::FromStr;
+
+use bzip2::write::{BzDecoder, BzEncoder};
+use bzip2::Compression;
 
 /// Represents what is returned from Analysis function
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -117,6 +118,31 @@ pub fn infer_dataset_types<R: std::io::Read>(
     Ok(types.into_iter().map(|(_, v)| (v.0, v.1)).collect())
 }
 
+/// Infers the training and prediction data based on whether the last column is empty.
+///
+/// This method will include the header of the data in both results, as this allows them to be used
+/// more easily later on. It does not allocate new strings either, meaning it should function well
+/// even with large datasets.
+pub fn infer_train_and_predict(data: &str) -> (Vec<&str>, Vec<&str>) {
+    let mut lines = data.split('\n');
+    let header = lines.next().unwrap();
+
+    // Include the header in both
+    let mut train = vec![header];
+    let mut predict = vec![header];
+
+    // Iterate the rest of the records
+    for record in lines {
+        if record.split(',').last().unwrap().is_empty() {
+            predict.push(record);
+        } else {
+            train.push(record);
+        }
+    }
+
+    (train, predict)
+}
+
 /// Returns a string containing CSV headers
 ///
 /// When a CSV dataset is being used, a user may want to form a string which
@@ -182,6 +208,22 @@ pub fn compress_data(data: &str) -> Result<Vec<u8>, std::io::Error> {
     write_compress.finish()
 }
 
+/// Compresses a vector of byte arrays into a single compression stream.
+pub fn compress_vec(data: &[&str]) -> Result<Vec<u8>, std::io::Error> {
+    let mut write_compress = BzEncoder::new(vec![], Compression::best());
+
+    for (i, e) in data.iter().enumerate() {
+        write_compress.write(e.as_bytes()).unwrap();
+
+        // Write newlines in for decompression
+        if i != data.len() - 1 {
+            write_compress.write(&[b'\n']).unwrap();
+        }
+    }
+
+    write_compress.finish()
+}
+
 /// Decompresses data and returns a result about the compression process
 ///
 /// Takes in compressed data as an array slice and writes it to the decompresssion
@@ -230,11 +272,39 @@ mod tests {
     }
 
     #[test]
+    fn train_and_predict_data_can_be_inferred() {
+        let dataset = "age,location\n20,Coventry\n20,\n21,Leamington";
+        let (data, predict) = infer_train_and_predict(dataset);
+
+        assert_eq!(data, vec!["age,location", "20,Coventry", "21,Leamington"]);
+        assert_eq!(predict, vec!["age,location", "20,"])
+    }
+
+    #[test]
     fn compression_full_stack() {
         let data = "Hello World!";
         let comp_data: Vec<u8> = compress_data(data).unwrap();
         let decomp_vec = decompress_data(&comp_data).unwrap();
         let decomp_data = std::str::from_utf8(&decomp_vec).unwrap();
         assert_eq!(data, decomp_data);
+    }
+
+    #[test]
+    fn vectors_can_be_compressed() {
+        let dataset = "age,location\n20,Coventry\n20,\n21,Leamington";
+        let (data, predict) = infer_train_and_predict(dataset);
+
+        let comp = compress_vec(&data).unwrap();
+        let decomp = decompress_data(&comp).unwrap();
+
+        assert_eq!(
+            std::str::from_utf8(&decomp).unwrap(),
+            "age,location\n20,Coventry\n21,Leamington"
+        );
+
+        let comp = compress_vec(&predict).unwrap();
+        let decomp = decompress_data(&comp).unwrap();
+
+        assert_eq!(std::str::from_utf8(&decomp).unwrap(), "age,location\n20,");
     }
 }


### PR DESCRIPTION
Infer the training and prediction data from the file upload given by the
user. This assumes the last column is the column that needs predicting
and splits the dataset based on whether this column is filled.

Datasets then store the training and prediction data as compressed in
the database, with both being returned when requested (but only the
training data shown currently).

This allows the machine learning to have some values to predict and thus
give results for.