### PR TITLE
Add constructors for each of the database models

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -105,7 +105,6 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "bzip2",
- "chrono",
  "config",
  "crypto",
  "csv",
@@ -1713,6 +1712,8 @@ dependencies = [
 name = "models"
 version = "0.1.0"
 dependencies = [
+ "chrono",
+ "crypto",
  "mongodb",
  "serde",
  "serde_json",

--- a/backend/api-server/Cargo.toml
+++ b/backend/api-server/Cargo.toml
@@ -14,7 +14,6 @@ serde_json = "1.0"
 pbkdf2 = "0.5.0"
 log = "0.4"
 toml = "0.5.7"
-chrono = "0.4"
 bzip2 = "0.4.1"
 csv = "1.1.3"
 config = { path = "../config" }

--- a/backend/api-server/src/routes/clients.rs
+++ b/backend/api-server/src/routes/clients.rs
@@ -34,7 +34,7 @@ pub async fn register(mut req: Request<State>) -> tide::Result {
 
     if let Some(user) = user {
         let peppered = format!("{}{}", password, pepper);
-        let verified = pbkdf2::pbkdf2_check(&peppered, &user.password).is_ok();
+        let verified = pbkdf2::pbkdf2_check(&peppered, &user.hash).is_ok();
 
         if verified && email == user.email {
             println!("Logged in: {:?}", user);

--- a/backend/api-server/tests/projects.rs
+++ b/backend/api-server/tests/projects.rs
@@ -38,7 +38,6 @@ async fn projects_can_be_fetched_for_a_user() -> tide::Result<()> {
 
     assert_eq!("Test Project", found.name);
     assert_eq!("Test Description", found.description);
-    assert_eq!(0, found.date_created.timestamp_millis());
 
     Ok(())
 }
@@ -89,7 +88,6 @@ async fn projects_can_be_fetched_by_identifier() -> tide::Result<()> {
 
     assert_eq!("Test Project", project_response.project.name);
     assert_eq!("Test Description", project_response.project.description);
-    assert_eq!(0, project_response.project.date_created.timestamp_millis());
 
     Ok(())
 }

--- a/backend/models/Cargo.toml
+++ b/backend/models/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2018"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 utils = { path = "../utils" }
+crypto = { path = "../crypto" }
+chrono = "0.4"
 
 [dependencies.mongodb]
 version = "1.1.0"

--- a/backend/models/src/dataset_details.rs
+++ b/backend/models/src/dataset_details.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use chrono::Utc;
 use mongodb::bson;
 use mongodb::bson::oid::ObjectId;
 
@@ -19,4 +20,21 @@ pub struct DatasetDetails {
     pub head: Option<String>,
     /// The types of each column
     pub column_types: HashMap<String, utils::DatasetType>,
+}
+
+impl DatasetDetails {
+    /// Creates a new instance of [`DatasetDetails`].
+    pub fn new(
+        project_id: ObjectId,
+        head: String,
+        column_types: HashMap<String, utils::DatasetType>,
+    ) -> Self {
+        Self {
+            id: None,
+            project_id: Some(project_id),
+            date_created: bson::DateTime(Utc::now()),
+            head: Some(head),
+            column_types,
+        }
+    }
 }

--- a/backend/models/src/projects.rs
+++ b/backend/models/src/projects.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+use chrono::Utc;
 use mongodb::bson;
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
@@ -45,4 +46,18 @@ pub struct Project {
     pub user_id: Option<ObjectId>,
     /// The status of the project
     pub status: Status,
+}
+
+impl Project {
+    /// Creates a new instance of [`Project`].
+    pub fn new<T: Into<String>>(name: T, description: T, user_id: ObjectId) -> Self {
+        Self {
+            id: None,
+            name: name.into(),
+            description: description.into(),
+            date_created: bson::DateTime(Utc::now()),
+            user_id: Some(user_id),
+            status: Status::Unfinished,
+        }
+    }
 }

--- a/backend/models/src/users.rs
+++ b/backend/models/src/users.rs
@@ -12,7 +12,7 @@ pub struct User {
     /// The user's email
     pub email: String,
     /// The peppered and hashed version of the user's password
-    pub password: String,
+    pub hash: String,
     /// The user's first name
     pub first_name: String,
     /// The user's last name
@@ -23,4 +23,20 @@ pub struct User {
     pub client: bool,
     /// The user's credits
     pub credits: i32,
+}
+
+impl User {
+    /// Creates a new instance of [`User`].
+    pub fn new<T: Into<String>>(email: T, hash: T, first_name: T, last_name: T) -> Self {
+        Self {
+            id: None,
+            email: email.into(),
+            hash: hash.into(),
+            first_name: first_name.into(),
+            last_name: last_name.into(),
+            api_key: crypto::generate_user_api_key(),
+            client: false,
+            credits: 10,
+        }
+    }
 }


### PR DESCRIPTION
Add a `new` constructor for each of the database models, allowing them
to be created more easily. This allows some constraints to be applied in
the constructor, reducing the likelihood of copy-paste errors.