### PR TITLE
Switch to stable Rust version for Docker image

### DIFF
--- a/backend/api-server/Dockerfile
+++ b/backend/api-server/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM rust:latest
 
-RUN rustup default nightly
+RUN rustup default stable
 RUN cargo install cargo-watch
 RUN rustc --version
 


### PR DESCRIPTION
### Overview

This PR changes the version of Rust used in the Docker image of `api-server` to use the latest `stable` version of the compiler in the place of the latest `nightly` version of the compiler as this is currently not required for the project.