### PR TITLE
Refactor the node end to make it more readable

### DIFF
--- a/backend/dcl/src/messages.rs
+++ b/backend/dcl/src/messages.rs
@@ -1,7 +1,5 @@
 //! Contains the builder functions used to generate message for DCL-DCN protcol
 
-use serde::{Deserialize, Serialize};
-
 /// Different messages to be passed between DCL and DCN
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Message {

--- a/backend/dcl/tests/comp_nodes.rs
+++ b/backend/dcl/tests/comp_nodes.rs
@@ -62,7 +62,7 @@ async fn test_node_connect_and_hb() {
 
     let info_read = nodepool.info.read().await;
     for (_, info) in info_read.iter() {
-        assert!(info.get_alive());
+        assert!(info.alive);
     }
 }
 

--- a/backend/models/Cargo.toml
+++ b/backend/models/Cargo.toml
@@ -11,9 +11,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 utils = { path = "../utils" }
 crypto = { path = "../crypto" }
-chrono = "0.4"
 
 [dependencies.mongodb]
 version = "1.1.0"
 default-features = false
 features = ["async-std-runtime"]
+
+[dependencies.chrono]
+version = "0.4"
+features = ["serde"]


### PR DESCRIPTION
Refactor the node end of the DCL to make it simpler and easier to read.
No functionality is changed. Remove some errant imports and fix my build
of `models` which was breaking due to lack of `serde`.