### PR TITLE
Avoid allocations for status enums

### DIFF
--- a/backend/api-server/src/routes/projects.rs
+++ b/backend/api-server/src/routes/projects.rs
@@ -188,7 +188,7 @@ pub async fn add_data(mut req: Request<State>) -> tide::Result {
         projects
             .update_one(
                 doc! { "_id": &object_id},
-                doc! {"$set": {"status": Status::Ready.to_string()}},
+                doc! {"$set": {"status": Status::Ready}},
                 None,
             )
             .await?;
@@ -304,7 +304,7 @@ pub async fn begin_processing(req: Request<State>) -> tide::Result {
     stream.shutdown(std::net::Shutdown::Both)?;
 
     // Mark the project as processing
-    let update = doc! { "$set": doc!{ "status": Status::Processing.to_string() } };
+    let update = doc! { "$set": doc!{ "status": Status::Processing } };
     projects
         .update_one(doc! { "_id": &object_id}, update, None)
         .await?;

--- a/backend/dcl/src/node_end/mod.rs
+++ b/backend/dcl/src/node_end/mod.rs
@@ -19,6 +19,8 @@ use mongodb::{
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::RwLock;
 
+use models::models::Status;
+
 pub mod protocol;
 
 /// Defines information about a Node
@@ -257,7 +259,7 @@ pub async fn update_model_status(database: Arc<Database>, model_id: &str) -> Res
 
     let object_id = ObjectId::with_string(model_id)?;
     let query = doc! {"_id": &object_id};
-    let update = doc! { "$set": { "status": "Running" } };
+    let update = doc! { "$set": { "status": Status::Running } };
     models.update_one(query, update, None).await?;
 
     Ok(())

--- a/backend/dcl/tests/common.rs
+++ b/backend/dcl/tests/common.rs
@@ -6,6 +6,8 @@ use mongodb::Database;
 use std::env;
 use std::str::FromStr;
 
+use models::projects::Status;
+
 pub static USER_ID: &str = "5f8ca1a80065f27b0089e8b5";
 pub static PROJECT_ID: &str = "5f8ca1a80065f27c0089e8b5";
 pub static DATASET_ID: &str = "5f8ca1a80065f27b0089e8b6";
@@ -73,7 +75,7 @@ pub async fn initialise_with_db() -> (Database, Params) {
         "description": "Test Description",
         "date_created": bson::Bson::DateTime(chrono::Utc.timestamp_millis(0)),
         "user_id": ObjectId::with_string(USER_ID).unwrap(),
-        "status": "Ready"
+        "status": Status::Ready,
     };
 
     let projects = database.collection("projects");

--- a/backend/models/src/models.rs
+++ b/backend/models/src/models.rs
@@ -3,8 +3,9 @@
 use std::fmt;
 
 use chrono::{DateTime, Duration, Utc};
+use mongodb::bson::{self, oid::ObjectId, Binary, Bson};
+
 use crypto::generate_access_token;
-use mongodb::bson::{self, oid::ObjectId, Binary};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Status {
@@ -13,13 +14,13 @@ pub enum Status {
     NotStarted,
 }
 
-impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Status::Running => write!(f, "Running"),
-            Status::Stopped => write!(f, "Stopped"),
-            Status::NotStarted => write!(f, "NotStarted"),
-        }
+impl From<Status> for Bson {
+    fn from(status: Status) -> Self {
+        Self::from(match status {
+            Status::Running => "Running",
+            Status::Stopped => "Stopped",
+            Status::NotStarted => "NotStarted",
+        })
     }
 }
 

--- a/backend/models/src/projects.rs
+++ b/backend/models/src/projects.rs
@@ -1,10 +1,7 @@
 //! Defines the structure of projects in the MongoDB instance.
 
-use std::fmt;
-
 use chrono::Utc;
-use mongodb::bson;
-use mongodb::bson::oid::ObjectId;
+use mongodb::bson::{self, oid::ObjectId, Bson};
 use serde::{Deserialize, Serialize};
 
 #[allow(missing_docs)]
@@ -18,15 +15,15 @@ pub enum Status {
     Read,
 }
 
-impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Status::Unfinished => write!(f, "Unfinished"),
-            Status::Ready => write!(f, "Ready"),
-            Status::Processing => write!(f, "Processing"),
-            Status::Complete => write!(f, "Complete"),
-            Status::Read => write!(f, "Read"),
-        }
+impl From<Status> for Bson {
+    fn from(status: Status) -> Self {
+        Self::from(match status {
+            Status::Unfinished => "Unfinished",
+            Status::Ready => "Ready",
+            Status::Processing => "Processing",
+            Status::Complete => "Complete",
+            Status::Read => "Read",
+        })
     }
 }
 


### PR DESCRIPTION
When updating the status of a project or model, this required us to have
a custom impl for `std::fmt::Display`, which would allocate a new
string each time. Instead, we can impl `From<State>` for `bson::Bson`
and use strings in the binaries.

In reality, this makes no difference to performance, but is a little
more ergonomic to use when changing the states.