### PR TITLE
Add a constructor for clients

### DIFF
--- a/backend/models/src/users.rs
+++ b/backend/models/src/users.rs
@@ -52,3 +52,13 @@ pub struct Client {
     /// This clients public Key
     pub public_key: String,
 }
+
+impl Client {
+    pub fn new(user_id: ObjectId, public_key: String) -> Self {
+        Self {
+            id: None,
+            user_id,
+            public_key,
+        }
+    }
+}


### PR DESCRIPTION
Add a `Client::new` function to simplify creation and in future remove
the need for ObjectIds being optional. All other models have
constructors so this is mostly keeping consistency.