### PR TITLE
Refactor the length prefixing into a trait

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1666,6 +1666,7 @@ name = "messages"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "log",
  "mongodb",
  "serde",

--- a/backend/api-server/src/routes/projects.rs
+++ b/backend/api-server/src/routes/projects.rs
@@ -17,7 +17,7 @@ use crate::dodona_error::DodonaError;
 use crate::routes::{check_project_exists, check_user_exists, response_from_json};
 use crate::AppState;
 use crypto::clean;
-use messages::interface::InterfaceMessage;
+use messages::{InterfaceMessage, WriteLengthPrefix};
 use models::dataset_details::DatasetDetails;
 use models::datasets::Dataset;
 use models::jobs::Job;
@@ -464,7 +464,7 @@ async fn forward_to_interface(msg: &InterfaceMessage) -> tokio::io::Result<()> {
 
     stream.write(&msg.as_bytes()).await?;
 
-    log::info!("Forwarded an message to the interface: {:?}", msg);
+    log::info!("Forwarded a message to the interface: {:?}", msg);
 
     Ok(())
 }

--- a/backend/dcl/src/health/mod.rs
+++ b/backend/dcl/src/health/mod.rs
@@ -15,7 +15,7 @@ use tokio::time::timeout;
 use anyhow::Result;
 
 use crate::node_end::NodePool;
-use messages::ClientMessage;
+use messages::{ClientMessage, WriteLengthPrefix};
 
 /// Runner for health checking
 ///

--- a/backend/dcl/src/interface_end/mod.rs
+++ b/backend/dcl/src/interface_end/mod.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc::Sender;
 use utils::compress::decompress_data;
 
 use crate::DatasetPair;
-use messages::{ClientMessage, InterfaceMessage};
+use messages::{ClientMessage, InterfaceMessage, ReadLengthPrefix};
 use models::datasets::Dataset;
 
 /// Starts up interface server

--- a/backend/dcl/src/job_end/mod.rs
+++ b/backend/dcl/src/job_end/mod.rs
@@ -14,7 +14,7 @@ use tokio::sync::RwLock;
 
 use crate::node_end::NodePool;
 use crate::DatasetPair;
-use messages::ClientMessage;
+use messages::{ClientMessage, ReadLengthPrefix, WriteLengthPrefix};
 use models::predictions::Prediction;
 
 use utils::anon::{anonymise_dataset, deanonymise_dataset};

--- a/backend/dcl/src/protocol/mod.rs
+++ b/backend/dcl/src/protocol/mod.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
-use messages::ClientMessage;
+use messages::{ClientMessage, RawMessage, ReadLengthPrefix, WriteLengthPrefix};
 
 #[cfg(test)]
 mod tests;
@@ -94,7 +94,7 @@ impl<'a> Handler<'a> {
         let endpoint = "/api/clients/m/new";
         let text = get_response_text(endpoint, body).await?;
 
-        let message = ClientMessage::RawJSON { content: text };
+        let message = RawMessage::new(text);
 
         // Send the response back to the client
         self.respond(&message.as_bytes()).await?;
@@ -125,7 +125,7 @@ impl<'a> Handler<'a> {
         let endpoint = "/api/clients/m/verify";
         let text = get_response_text(endpoint, body).await?;
 
-        let message = ClientMessage::RawJSON { content: text };
+        let message = RawMessage::new(text);
 
         // Send the response back to the client
         self.stream.write(&message.as_bytes()).await?;
@@ -151,7 +151,7 @@ impl<'a> Handler<'a> {
         let endpoint = "/api/clients/m/authenticate";
         let text = get_response_text(endpoint, body).await?;
 
-        let message = ClientMessage::RawJSON { content: text };
+        let message = RawMessage::new(text);
 
         // Send the response back to the client
         self.stream.write(&message.as_bytes()).await?;

--- a/backend/dcl/src/protocol/tests.rs
+++ b/backend/dcl/src/protocol/tests.rs
@@ -7,7 +7,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::protocol;
-use messages::ClientMessage;
+use messages::{ClientMessage, WriteLengthPrefix};
 
 #[tokio::test]
 async fn nodes_can_immediately_send_tokens() -> Result<(), Box<dyn Error>> {

--- a/backend/dcl/tests/interface.rs
+++ b/backend/dcl/tests/interface.rs
@@ -7,7 +7,7 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 
-use messages::InterfaceMessage;
+use messages::{InterfaceMessage, WriteLengthPrefix};
 
 mod common;
 

--- a/backend/interface/src/main.rs
+++ b/backend/interface/src/main.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio_stream::StreamExt;
 
 use config::Environment;
-use messages::InterfaceMessage;
+use messages::{InterfaceMessage, ReadLengthPrefix, WriteLengthPrefix};
 use models::jobs::Job;
 use utils::setup_logger;
 

--- a/backend/messages/Cargo.toml
+++ b/backend/messages/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = "1.0"
 log = "0.4"
 utils = { path = "../utils" }
 mongodb = { git = "https://github.com/alexander-jackson/mongo-rust-driver" }
+async-trait = "0.1.42"

--- a/backend/messages/src/client.rs
+++ b/backend/messages/src/client.rs
@@ -1,11 +1,5 @@
 //! Contains the builder functions used to generate message for DCL-DCN protcol
 
-use std::convert::TryInto;
-
-use anyhow::Result;
-use tokio::io::AsyncReadExt;
-use tokio::net::TcpStream;
-
 /// Different messages to be passed between DCL and DCN
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum ClientMessage {
@@ -58,65 +52,4 @@ pub enum ClientMessage {
         /// The raw JSON contents
         content: String,
     },
-}
-
-impl ClientMessage {
-    /// Reads a [`Message`] from a raw stream of bytes, dealing with length prefixing.
-    pub async fn from_stream(stream: &mut TcpStream, mut buffer: &mut [u8]) -> Result<Self> {
-        log::info!("Reading a message");
-
-        // Read the size of the message
-        let mut size_buffer = [0_u8; 4];
-        stream.read_exact(&mut size_buffer).await?;
-
-        // Convert it to a u32
-        let message_size = u32::from_be_bytes(size_buffer);
-        log::debug!("Received message length prefix: {}", message_size);
-
-        // Read again from the stream, extending the vector if needed
-        let mut bytes = Vec::new();
-        let mut remaining_size = message_size;
-
-        log::info!("Buffer length: {}", buffer.len());
-
-        while buffer.len() < remaining_size.try_into().unwrap() {
-            log::info!("Reading {} bytes from the stream", buffer.len());
-            stream.read(&mut buffer).await?;
-            bytes.extend_from_slice(buffer);
-            remaining_size -= buffer.len() as u32;
-        }
-
-        // Calculate the remaining number of bytes
-        let remaining = (remaining_size as usize) % buffer.len();
-        log::debug!("Remaining message size: {}", remaining_size);
-
-        // Enforce reading only `remaining` bytes
-        let mut truncated = stream.take(remaining as u64);
-        truncated.read(&mut buffer).await?;
-
-        bytes.extend_from_slice(&buffer[..remaining]);
-
-        Ok(serde_json::from_slice(&bytes)?)
-    }
-
-    /// Converts a [`Message`] into a vector of bytes.
-    pub fn as_bytes(&self) -> Vec<u8> {
-        log::info!("Writing a message");
-
-        // Convert the message to bytes
-        let bytes = match self {
-            ClientMessage::RawJSON { content } => content.as_bytes().to_vec(),
-            _ => serde_json::to_vec(&self).unwrap(),
-        };
-
-        // Prepend with the length
-        let length = bytes.len() as u32;
-        log::debug!("Sending message length prefix: {}", length);
-
-        let mut message = length.to_be_bytes().to_vec();
-        log::debug!("Message prefix: {:?}", message);
-        message.extend(bytes);
-
-        message
-    }
 }

--- a/backend/messages/src/interface.rs
+++ b/backend/messages/src/interface.rs
@@ -1,11 +1,6 @@
 //! Contains the builder functions used to generate messages for Interface - DCL Communication
 
-use std::convert::TryInto;
-
-use anyhow::Result;
 use mongodb::bson::oid::ObjectId;
-use tokio::io::AsyncReadExt;
-use tokio::net::TcpStream;
 
 /// Different messages to be passed between Interface and DCL
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -24,65 +19,4 @@ pub enum InterfaceMessage {
         /// The raw JSON contents
         content: String,
     },
-}
-
-impl InterfaceMessage {
-    /// Reads a [`Message`] from a raw stream of bytes, dealing with length prefixing.
-    pub async fn from_stream(stream: &mut TcpStream, mut buffer: &mut [u8]) -> Result<Self> {
-        log::info!("Reading a message");
-
-        // Read the size of the message
-        let mut size_buffer = [0_u8; 4];
-        stream.read_exact(&mut size_buffer).await?;
-
-        // Convert it to a u32
-        let message_size = u32::from_be_bytes(size_buffer);
-        log::debug!("Received message length prefix: {}", message_size);
-
-        // Read again from the stream, extending the vector if needed
-        let mut bytes = Vec::new();
-        let mut remaining_size = message_size;
-
-        log::info!("Buffer length: {}", buffer.len());
-
-        while buffer.len() < remaining_size.try_into().unwrap() {
-            log::info!("Reading {} bytes from the stream", buffer.len());
-            stream.read(&mut buffer).await?;
-            bytes.extend_from_slice(buffer);
-            remaining_size -= buffer.len() as u32;
-        }
-
-        // Calculate the remaining number of bytes
-        let remaining = (remaining_size as usize) % buffer.len();
-        log::debug!("Remaining message size: {}", remaining_size);
-
-        // Enforce reading only `remaining` bytes
-        let mut truncated = stream.take(remaining as u64);
-        truncated.read(&mut buffer).await?;
-
-        bytes.extend_from_slice(&buffer[..remaining]);
-
-        Ok(serde_json::from_slice(&bytes)?)
-    }
-
-    /// Converts a [`Message`] into a vector of bytes.
-    pub fn as_bytes(&self) -> Vec<u8> {
-        log::info!("Writing a message");
-
-        // Convert the message to bytes
-        let bytes = match self {
-            InterfaceMessage::RawJSON { content } => content.as_bytes().to_vec(),
-            _ => serde_json::to_vec(&self).unwrap(),
-        };
-
-        // Prepend with the length
-        let length = bytes.len() as u32;
-        log::debug!("Sending message length prefix: {}", length);
-
-        let mut message = length.to_be_bytes().to_vec();
-        log::debug!("Message prefix: {:?}", message);
-        message.extend(bytes);
-
-        message
-    }
 }

--- a/backend/messages/src/length_prefix.rs
+++ b/backend/messages/src/length_prefix.rs
@@ -1,0 +1,83 @@
+//! Contains a trait to allow any object to become length prefixed bytes.
+
+use std::convert::TryInto;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{de::DeserializeOwned, Serialize};
+use tokio::io::AsyncReadExt;
+use tokio::net::TcpStream;
+
+use crate::{ClientMessage, InterfaceMessage};
+
+// Implement reading and writing for our 2 message types
+impl ReadLengthPrefix for ClientMessage {}
+impl ReadLengthPrefix for InterfaceMessage {}
+
+impl WriteLengthPrefix for ClientMessage {}
+impl WriteLengthPrefix for InterfaceMessage {}
+
+/// Allows any object that is [`DeserializeOwned`] to be deserialized from length prefixed form.
+#[async_trait]
+pub trait ReadLengthPrefix: DeserializeOwned {
+    /// Reads a [`Message`] from a raw stream of bytes, dealing with length prefixing.
+    async fn from_stream<'a>(stream: &mut TcpStream, mut buffer: &mut [u8]) -> Result<Self> {
+        log::info!("Reading a message");
+
+        // Read the size of the message
+        let mut size_buffer = [0_u8; 4];
+        stream.read_exact(&mut size_buffer).await?;
+
+        // Convert it to a u32
+        let message_size = u32::from_be_bytes(size_buffer);
+        log::debug!("Received message length prefix: {}", message_size);
+
+        // Read again from the stream, extending the vector if needed
+        let mut bytes = Vec::new();
+        let mut remaining_size = message_size;
+
+        log::info!("Buffer length: {}", buffer.len());
+
+        while buffer.len() < remaining_size.try_into().unwrap() {
+            log::info!("Reading {} bytes from the stream", buffer.len());
+            stream.read(&mut buffer).await?;
+            bytes.extend_from_slice(buffer);
+            remaining_size -= buffer.len() as u32;
+        }
+
+        // Calculate the remaining number of bytes
+        let remaining = (remaining_size as usize) % buffer.len();
+        log::debug!("Remaining message size: {}", remaining_size);
+
+        // Enforce reading only `remaining` bytes
+        let mut truncated = stream.take(remaining as u64);
+        truncated.read(&mut buffer).await?;
+
+        bytes.extend_from_slice(&buffer[..remaining]);
+
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+}
+
+/// Allows any object that is [`Serialize`] to be serialized in length prefixed form.
+pub trait WriteLengthPrefix: Serialize {
+    /// Converts a [`Message`] into a vector of bytes.
+    fn as_bytes(&self) -> Vec<u8> {
+        // Convert the message to bytes
+        let bytes = serde_json::to_vec(&self).unwrap();
+
+        // Prepend with the length
+        let length = bytes.len() as u32;
+
+        let mut message = length.to_be_bytes().to_vec();
+        message.extend(bytes);
+
+        log::debug!(
+            "Message created with prefix: {}, total length: {}",
+            length,
+            message.len()
+        );
+
+        message
+    }
+}

--- a/backend/messages/src/lib.rs
+++ b/backend/messages/src/lib.rs
@@ -10,6 +10,10 @@ extern crate serde;
 
 pub mod client;
 pub mod interface;
+pub mod length_prefix;
+pub mod raw_message;
 
 pub use client::ClientMessage;
 pub use interface::InterfaceMessage;
+pub use length_prefix::{ReadLengthPrefix, WriteLengthPrefix};
+pub use raw_message::RawMessage;

--- a/backend/messages/src/raw_message.rs
+++ b/backend/messages/src/raw_message.rs
@@ -1,0 +1,39 @@
+//! Defines a message that can be sent without length prefixing, generally for raw JSON.
+
+use serde::Serialize;
+
+use crate::WriteLengthPrefix;
+
+/// Defines a message that will not be length prefixed when being sent.
+#[derive(Serialize)]
+pub struct RawMessage<T: Serialize> {
+    content: T,
+}
+
+impl<T: Serialize> RawMessage<T> {
+    /// Creates a new [`RawMessage`] that will only serialize the inner content.
+    pub fn new(content: T) -> Self {
+        Self { content }
+    }
+}
+
+impl<T: Serialize> WriteLengthPrefix for RawMessage<T> {
+    fn as_bytes(&self) -> Vec<u8> {
+        // Convert the inner content to bytes
+        let bytes = serde_json::to_vec(&self.content).unwrap();
+
+        // Prepend with the length
+        let length = bytes.len() as u32;
+
+        let mut message = length.to_be_bytes().to_vec();
+        message.extend(bytes);
+
+        log::debug!(
+            "Message created with prefix: {}, total length: {}",
+            length,
+            message.len()
+        );
+
+        message
+    }
+}


### PR DESCRIPTION
Length prefixing for messages previously shared an implementation
between both message types. This left it vulnerable to one being changed
without the update being propagated.

Instead, this adds a `ReadLengthPrefix` trait for reading a length
prefixed message from a stream and a `WriteLengthPrefix` trait for
converting a type into a vector of bytes prefixed with its length.

In some cases, we want to length prefix a message but not contain the
type information, such as when acting as a JSON proxy for the API
server. For this, the `RawMessage` type acts as a wrapper, only
serializing its contents.