### PR TITLE
Implement From<T> for various errors

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "log",
  "pbkdf2 0.5.0",
  "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/backend/api-server/src/dodona_error.rs
+++ b/backend/api-server/src/dodona_error.rs
@@ -1,6 +1,7 @@
 //! Defines error handling for the API server.
 
 use actix_web::{error::ResponseError, http::StatusCode, HttpResponse};
+use mongodb::bson;
 use serde::Serialize;
 use thiserror::Error;
 
@@ -17,8 +18,8 @@ pub enum DodonaError {
     #[error("Unknown Internal Error")]
     Unknown,
     /// UNPROCESSABLE_ENTITY HTTP Error
-    #[error("Invalid Request")]
-    Invalid,
+    #[error("Unprocessable Entity")]
+    UnprocessableEntity,
     /// Conflict HTTP Error
     #[error("Conflict")]
     Conflict,
@@ -34,10 +35,58 @@ impl DodonaError {
             Self::NotFound => "NotFound",
             Self::Forbidden => "Forbidden",
             Self::Unknown => "Unknown",
-            Self::Invalid => "Invalid",
+            Self::UnprocessableEntity => "UnprocessableEntity",
             Self::Conflict => "Conflict",
             Self::Unauthorized => "Unauthorized",
         }
+    }
+}
+
+impl From<std::str::Utf8Error> for DodonaError {
+    fn from(_error: std::str::Utf8Error) -> DodonaError {
+        DodonaError::UnprocessableEntity
+    }
+}
+
+impl From<bson::oid::Error> for DodonaError {
+    fn from(_error: bson::oid::Error) -> DodonaError {
+        DodonaError::UnprocessableEntity
+    }
+}
+
+impl From<bson::document::ValueAccessError> for DodonaError {
+    fn from(_error: bson::document::ValueAccessError) -> DodonaError {
+        DodonaError::UnprocessableEntity
+    }
+}
+
+impl From<bson::ser::Error> for DodonaError {
+    fn from(_error: bson::ser::Error) -> DodonaError {
+        DodonaError::UnprocessableEntity
+    }
+}
+
+impl From<bson::de::Error> for DodonaError {
+    fn from(_error: bson::de::Error) -> DodonaError {
+        DodonaError::UnprocessableEntity
+    }
+}
+
+impl From<mongodb::error::Error> for DodonaError {
+    fn from(_error: mongodb::error::Error) -> DodonaError {
+        DodonaError::Unknown
+    }
+}
+
+impl From<pbkdf2::CheckError> for DodonaError {
+    fn from(_error: pbkdf2::CheckError) -> DodonaError {
+        DodonaError::Unauthorized
+    }
+}
+
+impl From<utils::compress::CompressionError> for DodonaError {
+    fn from(_error: utils::compress::CompressionError) -> DodonaError {
+        DodonaError::UnprocessableEntity
     }
 }
 
@@ -48,7 +97,7 @@ impl ResponseError for DodonaError {
             Self::NotFound => StatusCode::NOT_FOUND,
             Self::Forbidden => StatusCode::FORBIDDEN,
             Self::Unknown => StatusCode::INTERNAL_SERVER_ERROR,
-            Self::Invalid => StatusCode::UNPROCESSABLE_ENTITY,
+            Self::UnprocessableEntity => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Conflict => StatusCode::CONFLICT,
             Self::Unauthorized => StatusCode::UNAUTHORIZED,
         }

--- a/backend/api-server/src/routes/mod.rs
+++ b/backend/api-server/src/routes/mod.rs
@@ -1,13 +1,13 @@
 //! Defines the routes for the API server.
 
-use crypto::clean_json;
+use actix_web::{HttpResponse, Result};
 use mongodb::{
-    bson::{doc, document::Document, oid::ObjectId},
+    bson::{doc, oid::ObjectId},
     Collection,
 };
 
 use crate::dodona_error::DodonaError;
-use actix_web::{HttpResponse, Result};
+use crypto::clean_json;
 
 pub mod clients;
 pub mod projects;
@@ -27,7 +27,7 @@ pub fn response_from_json<B: serde::Serialize>(body: B) -> Result<HttpResponse, 
 /// Checks whether a user exists with the given ID.
 pub async fn check_user_exists(id: &str, users: &Collection) -> Result<ObjectId, DodonaError> {
     // Check the project ID to make sure it exists
-    let object_id = ObjectId::with_string(&id).map_err(|_| DodonaError::Invalid)?;
+    let object_id = ObjectId::with_string(&id)?;
     let query = doc! { "_id": &object_id };
 
     users
@@ -45,7 +45,7 @@ pub async fn check_project_exists(
     projects: &Collection,
 ) -> Result<ObjectId, DodonaError> {
     // Check the project ID to make sure it exists
-    let object_id = ObjectId::with_string(&id).map_err(|_| DodonaError::Invalid)?;
+    let object_id = ObjectId::with_string(&id)?;
     let query = doc! { "_id": &object_id};
 
     projects
@@ -55,9 +55,4 @@ pub async fn check_project_exists(
         .ok_or(DodonaError::NotFound)?;
 
     Ok(object_id)
-}
-
-/// Gets a key from a document, or returns a 422 error if it doesn't exist.
-pub fn get_from_doc<'a>(document: &'a Document, key: &'a str) -> Result<&'a str, DodonaError> {
-    document.get_str(key).map_err(|_| DodonaError::Invalid)
 }

--- a/backend/api-server/tests/projects.rs
+++ b/backend/api-server/tests/projects.rs
@@ -249,10 +249,7 @@ async fn projects_cannot_be_created_for_non_existent_users() -> Result<()> {
 
     let res = test::call_service(&mut app, req).await;
 
-    assert_eq!(
-        actix_web::http::StatusCode::UNPROCESSABLE_ENTITY,
-        res.status()
-    );
+    assert_eq!(actix_web::http::StatusCode::NOT_FOUND, res.status());
 
     Ok(())
 }

--- a/backend/dcl/src/interface_end/mod.rs
+++ b/backend/dcl/src/interface_end/mod.rs
@@ -59,7 +59,6 @@ async fn process_connection(
                 timeout,
                 column_types,
             } => (id, timeout, column_types),
-            _ => unreachable!(),
         };
 
     log::info!("Received a message from the interface:");

--- a/backend/utils/Cargo.toml
+++ b/backend/utils/Cargo.toml
@@ -14,6 +14,7 @@ bzip2 = "0.4.1"
 anyhow = "1.0"
 pbkdf2 = "0.5.0"
 chrono = "0.4.19"
+thiserror = "1.0.23"
 
 [dependencies.fern]
 version = "0.5"


### PR DESCRIPTION
Allow the API server to more easily propagate errors and reduce
boilerplate code using `map_err`. This ensures errors are consistent
with each other and allows the code to be simpler.

Fixes #183.