### PR TITLE
Remove a lot of unwraps

### DIFF
--- a/backend/api-server/src/dodona_error.rs
+++ b/backend/api-server/src/dodona_error.rs
@@ -42,52 +42,30 @@ impl DodonaError {
     }
 }
 
-impl From<std::str::Utf8Error> for DodonaError {
-    fn from(_error: std::str::Utf8Error) -> DodonaError {
-        DodonaError::UnprocessableEntity
+/// Allows impl From<Error> to be generated more easily for various errors
+macro_rules! error_map {
+    ($($error:path => $code:ident,)*) => {
+        $(
+            impl From<$error> for DodonaError {
+                fn from(_error: $error) -> Self {
+                    Self::$code
+                }
+            }
+        )*
     }
 }
 
-impl From<bson::oid::Error> for DodonaError {
-    fn from(_error: bson::oid::Error) -> DodonaError {
-        DodonaError::UnprocessableEntity
-    }
-}
-
-impl From<bson::document::ValueAccessError> for DodonaError {
-    fn from(_error: bson::document::ValueAccessError) -> DodonaError {
-        DodonaError::UnprocessableEntity
-    }
-}
-
-impl From<bson::ser::Error> for DodonaError {
-    fn from(_error: bson::ser::Error) -> DodonaError {
-        DodonaError::UnprocessableEntity
-    }
-}
-
-impl From<bson::de::Error> for DodonaError {
-    fn from(_error: bson::de::Error) -> DodonaError {
-        DodonaError::UnprocessableEntity
-    }
-}
-
-impl From<mongodb::error::Error> for DodonaError {
-    fn from(_error: mongodb::error::Error) -> DodonaError {
-        DodonaError::Unknown
-    }
-}
-
-impl From<pbkdf2::CheckError> for DodonaError {
-    fn from(_error: pbkdf2::CheckError) -> DodonaError {
-        DodonaError::Unauthorized
-    }
-}
-
-impl From<utils::compress::CompressionError> for DodonaError {
-    fn from(_error: utils::compress::CompressionError) -> DodonaError {
-        DodonaError::UnprocessableEntity
-    }
+error_map! {
+    std::str::Utf8Error => UnprocessableEntity,
+    std::num::ParseIntError => UnprocessableEntity,
+    bson::oid::Error => UnprocessableEntity,
+    bson::document::ValueAccessError => UnprocessableEntity,
+    bson::ser::Error => UnprocessableEntity,
+    bson::de::Error => UnprocessableEntity,
+    mongodb::error::Error => Unknown,
+    pbkdf2::CheckError => Unauthorized,
+    base64::DecodeError => UnprocessableEntity,
+    utils::compress::CompressionError => UnprocessableEntity,
 }
 
 impl ResponseError for DodonaError {

--- a/backend/api-server/src/routes/mod.rs
+++ b/backend/api-server/src/routes/mod.rs
@@ -32,8 +32,7 @@ pub async fn check_user_exists(id: &str, users: &Collection) -> Result<ObjectId,
 
     users
         .find_one(query, None)
-        .await
-        .unwrap()
+        .await?
         .ok_or(DodonaError::NotFound)?;
 
     Ok(object_id)
@@ -50,8 +49,7 @@ pub async fn check_project_exists(
 
     projects
         .find_one(query, None)
-        .await
-        .unwrap()
+        .await?
         .ok_or(DodonaError::NotFound)?;
 
     Ok(object_id)


### PR DESCRIPTION
Now that `impl From<Error> for DodonaError` is so much easier compared
to Tide, remove a lot of unwraps and replace them with `?` for easier
propagation.

Add a macro for adding `impl From<Error>` so that the file isn't as
cluttered.