### PR TITLE
Simplify the tests using a macro to build the API

### DIFF
--- a/backend/api-server/tests/common.rs
+++ b/backend/api-server/tests/common.rs
@@ -8,6 +8,27 @@ use config::Environment;
 use models::projects::Project;
 use models::users::User;
 
+macro_rules! api_with {
+    ($method:path: $route:literal => $handler:path) => {
+        test::init_service(
+            App::new()
+                .wrap(middleware::Logger::default())
+                .data(common::initialise().await)
+                .route($route, $method().to($handler)),
+        )
+        .await;
+    };
+    ($($method:path: $route:literal => $handler:path,)*) => {
+        test::init_service(
+            App::new()
+                .wrap(middleware::Logger::default())
+                .data(common::initialise().await)
+                $(.route($route, $method().to($handler)))*,
+        )
+        .await;
+    };
+}
+
 // Hardcoded random identifiers for various tests
 pub static MAIN_USER_ID: &str = "5f8ca1a80065f27b0089e8b5";
 pub static DELETE_UID: &str = "5fbe3239ea6cfda08a459622";

--- a/backend/api-server/tests/users.rs
+++ b/backend/api-server/tests/users.rs
@@ -1,11 +1,14 @@
-use serde::Deserialize;
+use actix_web::web::post;
+use actix_web::{middleware, test, App, Result};
+use api_server::routes::users;
+use mongodb::bson::{doc, document::Document};
 
 use models::users::User;
 
-use actix_web::{middleware, test, web, App, Result};
-use api_server::routes;
-use mongodb::bson::{doc, document::Document};
+#[macro_use]
+extern crate serde;
 
+#[macro_use]
 mod common;
 
 use common::get_bearer_token;
@@ -17,14 +20,7 @@ struct AuthResponse {
 
 #[actix_rt::test]
 async fn users_can_register() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/new", web::post().to(routes::users::new)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/new" => users::new };
 
     let doc = doc! {
         "email": "johnsmith@email.com",
@@ -49,14 +45,7 @@ async fn users_can_register() -> Result<()> {
 
 #[actix_rt::test]
 async fn users_cannot_register_twice() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/new", web::post().to(routes::users::new)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/new" => users::new };
 
     let doc = doc! {
         "email": "matthewsmith@email.com",
@@ -81,14 +70,7 @@ async fn users_cannot_register_twice() -> Result<()> {
 
 #[actix_rt::test]
 async fn users_can_login() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/login", web::post().to(routes::users::login)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/login" => users::login };
 
     let doc = doc! {
         "email": "matthewsmith@email.com",
@@ -111,14 +93,7 @@ async fn users_can_login() -> Result<()> {
 
 #[actix_rt::test]
 async fn users_cannot_login_without_correct_password() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/login", web::post().to(routes::users::login)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/login" => users::login };
 
     let doc = doc! {
         "email": "matthewsmith@email.com",
@@ -138,14 +113,7 @@ async fn users_cannot_login_without_correct_password() -> Result<()> {
 
 #[actix_rt::test]
 async fn users_cannot_login_without_correct_email() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/login", web::post().to(routes::users::login)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/login" => users::login };
 
     let doc = doc! {
         "email": "incorrect@email.com",
@@ -165,14 +133,7 @@ async fn users_cannot_login_without_correct_email() -> Result<()> {
 
 #[actix_rt::test]
 async fn filter_finds_given_user_and_no_others() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/filter", web::post().to(routes::users::filter)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/filter" => users::filter };
 
     let doc = doc! {"email": "matthewsmith@email.com"};
     let req = test::TestRequest::default()
@@ -198,14 +159,7 @@ async fn filter_finds_given_user_and_no_others() -> Result<()> {
 
 #[actix_rt::test]
 async fn non_existent_users_are_not_found() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/filter", web::post().to(routes::users::filter)),
-    )
-    .await;
+    let mut app = api_with! { post: "/api/users/filter" => users::filter };
 
     let doc = doc! {"email": "nonexistent@email.com"};
     let req = test::TestRequest::default()
@@ -225,15 +179,10 @@ async fn non_existent_users_are_not_found() -> Result<()> {
 
 #[actix_rt::test]
 async fn users_can_be_deleted() -> Result<()> {
-    let state = common::initialise().await;
-    let mut app = test::init_service(
-        App::new()
-            .wrap(middleware::Logger::default())
-            .data(state)
-            .route("/api/users/filter", web::post().to(routes::users::filter))
-            .route("/api/users/delete", web::post().to(routes::users::delete)),
-    )
-    .await;
+    let mut app = api_with! {
+        post: "/api/users/filter" => users::filter,
+        post: "/api/users/delete" => users::delete,
+    };
 
     // Find the user
     let doc = doc! {"email": "delete@me.com"};


### PR DESCRIPTION
A lot of the code in the tests is repeated, getting the state for the API and then setting up the test server to send requests at. This is also quite hard to read, and discourages people from adding more tests.

Instead, we can use a simple macro to build the API and fetch the state each time. This takes the method, route and handler and builds the API for you, removing ~10 lines of code each time it's used and making it much easier to see which routes are being used.

Hopefully a similar approach is possible for sending requests, at which point testing the API can be a lot better structured.
