### PR TITLE
Only run CI jobs when the backend changes

### DIFF
--- a/.github/workflows/cargo-fmt.yml
+++ b/.github/workflows/cargo-fmt.yml
@@ -3,6 +3,8 @@ name: cargo fmt
 on:
   pull_request:
     branches: [ master, develop ]
+    paths:
+    - "backend/**"
 
 jobs:
   build:

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -3,6 +3,8 @@ name: cargo test
 on:
   pull_request:
     branches: [ master, develop ]
+    paths:
+    - "backend/**"
 
 jobs:
   build:


### PR DESCRIPTION
Pull requests such as #213 only change the frontend, meaning there is no way for the CI to fail if it passed before. Instead, this `should` change it so that the pipelines will only run if something in `backend/` has changed.
