### PR TITLE
Allow JWTs to expire

### DIFF
--- a/backend/api-server/src/auth/tests.rs
+++ b/backend/api-server/src/auth/tests.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use actix_web::test::TestRequest;
 use jsonwebtoken::{EncodingKey, Header};
@@ -93,21 +93,13 @@ fn request_with_valid_token_is_accepted() {
 
 #[test]
 fn jwt_tokens_can_expire() {
-    // Get the current timestamp since the epoch
-    let current = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-
     // Create a new user with a random ObjectId
     let id = ObjectId::new();
-    // Set the expiry to be 1 second from now
-    let user = Claims::new(id, current.as_secs());
-
-    // Setup the JWT with the same settings as above
-    let header = Header::default();
-    let key = get_encoding_key();
-    let encoded = jsonwebtoken::encode(&header, &user, &key).unwrap();
+    // Set the token to expire almost immediately, we can get 1 request in first
+    let token = Claims::create_token_with_duration(id, Duration::default()).unwrap();
 
     // Build the request with the produced token
-    let auth_value = format!("Bearer {}", encoded);
+    let auth_value = format!("Bearer {}", token);
     let request = TestRequest::default()
         .header("Authorization", auth_value)
         .to_http_request();


### PR DESCRIPTION
Previously, JWTs would expire technically speaking, but only in the year
292,277,026,596 (292 billion). By this point, lots of interesting things
would have happened [[1]], such as the evolution of the Sun into a red
giant, Jupiter potentially causing Mercury to collide with Venus and
the concept of time becoming a little distorted. In 50,000 years we
will need a leap second every day just to keep up, so imagine what it
will be like when these tokens expire. We'd also have collided with the
Andromeda galaxy (and numerous other issues), but at least the tokens
are still good to go.

Anyway, tokens expire after 2 weeks now. Fixes #210.

[1]: https://en.wikipedia.org/wiki/Timeline_of_the_far_future