### PR TITLE
Update the MongoDB dependencies to be official

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1734,8 +1734,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "1.1.1"
-source = "git+https://github.com/mongodb/mongo-rust-driver?rev=64e00e8#64e00e8bda290b56f3ff7b850373f2ed102ce4ad"
+version = "2.0.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b63adec24cd1347d765124a8d9b427207a69407fe28bf48d04d39e0ffcbe83"
 dependencies = [
  "async-trait",
  "base64 0.11.0",

--- a/backend/api-server/Cargo.toml
+++ b/backend/api-server/Cargo.toml
@@ -29,6 +29,6 @@ messages = { path = "../messages" }
 crypto = { path = "../crypto" }
 models = { path = "../models" }
 utils = { path = "../utils" }
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", rev = "64e00e8" }
+mongodb = "2.0.0-alpha"
 futures-util = "0.3.12"
 jsonwebtoken = "7.2.0"

--- a/backend/dcl/Cargo.toml
+++ b/backend/dcl/Cargo.toml
@@ -23,7 +23,7 @@ models = { path = "../models" }
 utils = { path = "../utils" }
 messages = { path = "../messages" }
 chrono = "0.4.19"
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", rev = "64e00e8" }
+mongodb = "2.0.0-alpha"
 
 [dev-dependencies]
 pbkdf2 = "0.5.0"

--- a/backend/interface/Cargo.toml
+++ b/backend/interface/Cargo.toml
@@ -13,7 +13,7 @@ config = { path = "../config" }
 models = { path = "../models" }
 utils = { path = "../utils" }
 messages = { path = "../messages" }
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", rev = "64e00e8" }
+mongodb = "2.0.0-alpha"
 tokio-stream = "0.1.1"
 anyhow = "1.0.37"
 

--- a/backend/messages/Cargo.toml
+++ b/backend/messages/Cargo.toml
@@ -13,5 +13,5 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 utils = { path = "../utils" }
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", rev = "64e00e8" }
+mongodb = "2.0.0-alpha"
 async-trait = "0.1.42"

--- a/backend/models/Cargo.toml
+++ b/backend/models/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 utils = { path = "../utils" }
 crypto = { path = "../crypto" }
 messages = { path = "../messages" }
-mongodb = { git = "https://github.com/mongodb/mongo-rust-driver", rev = "64e00e8" }
+mongodb = "2.0.0-alpha"
 
 [dependencies.chrono]
 version = "0.4"


### PR DESCRIPTION
Update our dependencies on MongoDB to use the `master` branch of the official repository, which recently upgraded to Tokio 1. An official release seems to be version 2, which could potentially take a while to come out.
