### PR TITLE
Use the `float-cmp` crate to compare floats

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "config",
  "crypto",
  "csv",
+ "float-cmp",
  "futures",
  "http",
  "httparse",
@@ -1035,6 +1036,15 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]

--- a/backend/dcl/Cargo.toml
+++ b/backend/dcl/Cargo.toml
@@ -28,9 +28,10 @@ chrono = "0.4.19"
 mongodb = "2.0.0-alpha"
 
 [dev-dependencies]
-pbkdf2 = "0.5.0"
 chrono = "0.4"
+float-cmp = "0.8.0"
 mockito = "0.28.0"
+pbkdf2 = "0.5.0"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/backend/dcl/tests/job.rs
+++ b/backend/dcl/tests/job.rs
@@ -3,6 +3,7 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 use std::time::Duration;
 
+use float_cmp::approx_eq;
 use mongodb::bson::{doc, oid::ObjectId};
 
 use dcl::job_end::finance::Pricing;
@@ -98,15 +99,15 @@ fn test_evaluate_model() {
 
     let predictions = "1,4\n2,3\n3,2\n4,1".to_owned();
     let (_, model_error) = evaluate_model(&id, &predictions, &info);
-    assert_eq!(model_error, 5.0);
+    assert!(approx_eq!(f64, model_error, 5.0, ulps = 2));
 
     let predictions = "1,1\n2,3\n3,2\n4,4".to_owned();
     let (_, model_error) = evaluate_model(&id, &predictions, &info);
-    assert_eq!(model_error, 3.0);
+    assert!(approx_eq!(f64, model_error, 3.0, ulps = 2));
 
     let predictions = "1,1\n2,2\n3,3\n4,4\n5,5\n6,6\n7,7\n8,8".to_owned();
     let (model_predictions, model_error) = evaluate_model(&id, &predictions, &info);
-    assert_eq!(model_error, 1.0);
+    assert!(approx_eq!(f64, model_error, 1.0, ulps = 2));
     assert_eq!(model_predictions, test_predictions);
 }
 
@@ -172,7 +173,8 @@ fn test_weight_predictions() {
     }
 
     let (weights, final_predictions) = weight_predictions(model_predictions, model_errors);
-    assert_eq!(weights.values().sum::<f64>(), 1.0);
+    let sum = weights.values().sum::<f64>();
+    assert!(approx_eq!(f64, sum, 1.0, ulps = 2));
     assert_eq!(final_predictions.join("\n"), "5\n6\n7\n8");
 }
 


### PR DESCRIPTION
The GitHub CI seems to break, as it compares 0.999999 to 1 and finds they are not equal. Instead of using strict equality, `float-cmp` adds some lenience into the comparison. While the tests pass locally for me using either method, this is technically more correct and should work in the CI builds as well.
