### PR TITLE
Allow processing to take `u32` instead of `str`

### DIFF
--- a/backend/api-server/tests/projects.rs
+++ b/backend/api-server/tests/projects.rs
@@ -423,3 +423,41 @@ async fn projects_can_be_edited() -> Result<()> {
     assert_eq!("new description", project_response.project.description);
     Ok(())
 }
+
+#[actix_rt::test]
+async fn job_configs_can_have_integer_timeouts_in_json() -> Result<()> {
+    let mut app = api_with! {
+        put: "/api/projects/p/{project_id}/data" => projects::add_data,
+        post: "/api/projects/p/{project_id}/process" => projects::begin_processing,
+    };
+
+    let doc = doc! {"content": "age,sex,location\n22,M,Leamington Spa", "name": "Freddie"};
+    let url = format!("/api/projects/p/{}/data", common::MAIN_PROJECT_ID);
+
+    let req = test::TestRequest::default()
+        .method(actix_web::http::Method::PUT)
+        .header("Authorization", get_bearer_token(common::MAIN_USER_ID))
+        .uri(&url)
+        .set_json(&doc)
+        .to_request();
+
+    let res = test::call_service(&mut app, req).await;
+
+    assert_eq!(actix_web::http::StatusCode::OK, res.status());
+
+    let formatted = format!("/api/projects/p/{}/process", common::MAIN_PROJECT_ID);
+    let doc =
+        doc! { "timeout": 10 , "predictionType": "classification", "predictionColumn": "name"};
+    let req = test::TestRequest::default()
+        .method(actix_web::http::Method::POST)
+        .header("Authorization", get_bearer_token(common::MAIN_USER_ID))
+        .uri(&formatted)
+        .set_json(&doc)
+        .to_request();
+
+    let res = test::call_service(&mut app, req).await;
+
+    assert_eq!(actix_web::http::StatusCode::OK, res.status());
+
+    Ok(())
+}


### PR DESCRIPTION
When uploading the job configuration, allow a raw JSON integer instead of forcing it to be a string by using a `struct` instead.

Add a test to ensure this will continue to work.

Fixes #196.
