### PR TITLE
fixed output reloading

### DIFF
--- a/web/src/components/ProjectOutput.vue
+++ b/web/src/components/ProjectOutput.vue
@@ -2,7 +2,7 @@
   <b-container fluid class="mt-3">
     <b-row>
       <b-col v-if="!results && !loading" class="text-center">
-        <b-button @click="$emit('get-results')" variant="warning" class="px-5"
+        <b-button @click="getResults()" variant="warning" class="px-5"
           >Load Results</b-button
         >
       </b-col>
@@ -45,12 +45,29 @@ export default {
   name: "ProjectOutput",
   props: {
     projectId: String,
-    results: Array,
-    predict_data: String,
     datasetName: String,
-    loading: Boolean,
   },
+    data() {
+    return {
+      results: null,
+      predict_data: "",
+      loading: false
+    };
+  },
+
   methods: {
+    async getResults(){
+      this.loading = true;
+      
+      let project_predictions = await this.$http.get(
+          `http://localhost:3001/api/projects/p/${this.projectId}/predictions`
+        );
+
+      this.results = project_predictions.data["predictions"];
+      this.predict_data = project_predictions.data["predict_data"];
+      this.loading = false;
+
+    },
     parseData(data) {
       
       return Papa.parse(this.getFullPredictions(data), { header: true }).data

--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -37,10 +37,7 @@
             :projectId="projectId"
             :key="projectId"
             @get-results="fetchResults"
-            :results="results"
-            :predict_data="predict_data"
             :datasetName="datasetName"
-            :loading="results_loading"
           />
         </b-tab>
         <b-tab title="Settings" lazy>
@@ -139,16 +136,6 @@ export default {
 
       this.data = Papa.parse(project_data, { header: true });
       this.loading = false;
-    },
-    async fetchResults() {
-      this.results_loading = true;
-
-      let project_predictions = await this.$http.get(
-        `http://localhost:3001/api/projects/p/${this.projectId}/predictions`
-      );
-      this.results = project_predictions.data["predictions"];
-      this.predict_data = project_predictions.data["predict_data"];
-      this.results_loading = false;
     },
     resetProject() {
       // this.name = "";


### PR DESCRIPTION
This PR fixes #273 where it loads the data within the output component instead of in the parent meaning the correct results data is loaded.