### PR TITLE
Update the CI to use latest Rust

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -15,7 +15,15 @@ jobs:
       with:
         mongodb-version: 4.4
 
-    - name: cargo test
-      uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --manifest-path backend/Cargo.toml
 
     - run: "cd backend && cargo test"


### PR DESCRIPTION
Update GitHub Actions to use the latest version of Rust, allowing it to be independent of operating system packaged versions.
