### PR TITLE
Rename API routes based on suggestions

### DIFF
--- a/backend/api-server/src/lib.rs
+++ b/backend/api-server/src/lib.rs
@@ -86,15 +86,15 @@ pub async fn build_server() -> Result<actix_web::dev::Server> {
                     .expect("PBKDF2_ITERATIONS must be parseable as an integer"),
             })
             .route(
-                "/api/projects/p/{project_id}",
+                "/api/projects/{project_id}",
                 web::get().to(routes::projects::get_project),
             )
             .route(
-                "/api/projects/p/{project_id}",
+                "/api/projects/{project_id}",
                 web::patch().to(routes::projects::patch_project),
             )
             .route(
-                "/api/projects/p/{project_id}",
+                "/api/projects/{project_id}",
                 web::delete().to(routes::projects::delete_project),
             )
             .route(
@@ -103,27 +103,27 @@ pub async fn build_server() -> Result<actix_web::dev::Server> {
             )
             .route("/api/projects/new", web::post().to(routes::projects::new))
             .route(
-                "/api/projects/p/{project_id}/data",
+                "/api/projects/{project_id}/data",
                 web::put().to(routes::projects::add_data),
             )
             .route(
-                "/api/projects/p/{project_id}/overview",
+                "/api/projects/{project_id}/overview",
                 web::post().to(routes::projects::overview),
             )
             .route(
-                "/api/projects/p/{project_id}/data",
+                "/api/projects/{project_id}/data",
                 web::get().to(routes::projects::get_data),
             )
             .route(
-                "/api/projects/p/{project_id}/data",
+                "/api/projects/{project_id}/data",
                 web::delete().to(routes::projects::remove_data),
             )
             .route(
-                "/api/projects/p/{project_id}/process",
+                "/api/projects/{project_id}/process",
                 web::post().to(routes::projects::begin_processing),
             )
             .route(
-                "/api/projects/p/{project_id}/predictions",
+                "/api/projects/{project_id}/predictions",
                 web::get().to(routes::projects::get_predictions),
             )
             // Clients
@@ -132,27 +132,27 @@ pub async fn build_server() -> Result<actix_web::dev::Server> {
                 web::post().to(routes::clients::register),
             )
             .route(
-                "/api/clients/m/new",
+                "/api/clients/models/new",
                 web::post().to(routes::clients::new_model),
             )
             .route(
-                "/api/clients/m/verify",
+                "/api/clients/models/verify",
                 web::post().to(routes::clients::verify_challenge),
             )
             .route(
-                "/api/clients/m/{model_id}/unlock",
+                "/api/clients/models/{model_id}/unlock",
                 web::post().to(routes::clients::unlock_model),
             )
             .route(
-                "/api/clients/m/{model_id}/authenticate",
+                "/api/clients/models/{model_id}/authenticate",
                 web::post().to(routes::clients::authenticate_model),
             )
             .route(
-                "/api/clients",
+                "/api/clients/models",
                 web::get().to(routes::clients::get_user_models),
             )
             .route(
-                "/api/clients/m/{model_id}/performance",
+                "/api/clients/models/{model_id}/performance",
                 web::get().to(routes::clients::get_model_performance),
             )
             // users

--- a/backend/api-server/tests/clients.rs
+++ b/backend/api-server/tests/clients.rs
@@ -70,13 +70,13 @@ async fn users_cannot_become_clients_twice() {
 #[actix_rt::test]
 async fn model_performances_can_be_fetched() {
     let mut app = api_with! {
-        get: "/api/clients/m/{model_id}/performance" => clients::get_model_performance,
+        get: "/api/clients/models/{model_id}/performance" => clients::get_model_performance,
     };
 
     let results: Vec<f64> = vec![0.4, 0.5, 0.6];
     let doc = doc! {"id": common::MODEL_ID};
 
-    let url = format!("/api/clients/m/{}/performance", common::MODEL_ID);
+    let url = format!("/api/clients/models/{}/performance", common::MODEL_ID);
 
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)

--- a/backend/api-server/tests/projects.rs
+++ b/backend/api-server/tests/projects.rs
@@ -52,9 +52,9 @@ async fn projects_can_be_fetched_for_a_user() -> Result<()> {
 
 #[actix_rt::test]
 async fn projects_can_be_fetched_by_identifier() -> Result<()> {
-    let mut app = api_with! { get: "/api/projects/p/{project_id}" => projects::get_project };
+    let mut app = api_with! { get: "/api/projects/{project_id}" => projects::get_project };
 
-    let formatted = format!("/api/projects/p/{}", common::MAIN_PROJECT_ID);
+    let formatted = format!("/api/projects/{}", common::MAIN_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -93,9 +93,9 @@ async fn projects_can_be_fetched_by_identifier() -> Result<()> {
 
 #[actix_rt::test]
 async fn projects_cannot_be_fetched_by_users_who_do_not_own_it() -> Result<()> {
-    let mut app = api_with! { get: "/api/projects/p/{project_id}" => projects::get_project };
+    let mut app = api_with! { get: "/api/projects/{project_id}" => projects::get_project };
 
-    let formatted = format!("/api/projects/p/{}", common::MAIN_PROJECT_ID);
+    let formatted = format!("/api/projects/{}", common::MAIN_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header(("Authorization", get_bearer_token(common::DELETE_UID)))
@@ -111,9 +111,9 @@ async fn projects_cannot_be_fetched_by_users_who_do_not_own_it() -> Result<()> {
 
 #[actix_rt::test]
 async fn non_existent_projects_are_not_found() -> Result<()> {
-    let mut app = api_with! { get: "/api/projects/p/{project_id}" => projects::get_project };
+    let mut app = api_with! { get: "/api/projects/{project_id}" => projects::get_project };
 
-    let formatted = format!("/api/projects/p/{}", common::NON_EXISTENT_PROJECT_ID);
+    let formatted = format!("/api/projects/{}", common::NON_EXISTENT_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -129,9 +129,9 @@ async fn non_existent_projects_are_not_found() -> Result<()> {
 
 #[actix_rt::test]
 async fn projects_cannot_be_found_with_invalid_identifiers() -> Result<()> {
-    let mut app = api_with! { get: "/api/projects/p/{project_id}" => projects::get_project };
+    let mut app = api_with! { get: "/api/projects/{project_id}" => projects::get_project };
 
-    let url = "/api/projects/p/invalid";
+    let url = "/api/projects/invalid";
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -174,10 +174,10 @@ async fn projects_can_be_created() -> Result<()> {
 
 #[actix_rt::test]
 async fn datasets_can_be_added_to_projects() -> Result<()> {
-    let mut app = api_with! { put: "/api/projects/p/{project_id}/data" => projects::add_data };
+    let mut app = api_with! { put: "/api/projects/{project_id}/data" => projects::add_data };
 
     let doc = doc! {"content": "age,sex,location\n22,M,Leamington Spa", "name": "Freddie"};
-    let url = format!("/api/projects/p/{}/data", common::MAIN_PROJECT_ID);
+    let url = format!("/api/projects/{}/data", common::MAIN_PROJECT_ID);
 
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
@@ -196,15 +196,12 @@ async fn datasets_can_be_added_to_projects() -> Result<()> {
 #[actix_rt::test]
 async fn only_one_dataset_can_be_added_to_a_project() -> Result<()> {
     let mut app = api_with! {
-        put: "/api/projects/p/{project_id}/data" => projects::add_data,
-        get: "/api/projects/p/{project_id}/data" => projects::get_data,
+        put: "/api/projects/{project_id}/data" => projects::add_data,
+        get: "/api/projects/{project_id}/data" => projects::get_data,
     };
 
     let doc = doc! {"content": "age,sex,location\n23,M,Leamington Spa", "name": "Freddie"};
-    let url = format!(
-        "/api/projects/p/{}/data",
-        common::OVERWRITTEN_DATA_PROJECT_ID
-    );
+    let url = format!("/api/projects/{}/data", common::OVERWRITTEN_DATA_PROJECT_ID);
 
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
@@ -221,10 +218,7 @@ async fn only_one_dataset_can_be_added_to_a_project() -> Result<()> {
     assert_eq!(actix_web::http::StatusCode::OK, res.status());
 
     let doc = doc! {"content": "age,sex,location\n23,M,Coventry", "name": "Freddie"};
-    let url = format!(
-        "/api/projects/p/{}/data",
-        common::OVERWRITTEN_DATA_PROJECT_ID
-    );
+    let url = format!("/api/projects/{}/data", common::OVERWRITTEN_DATA_PROJECT_ID);
 
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
@@ -240,10 +234,7 @@ async fn only_one_dataset_can_be_added_to_a_project() -> Result<()> {
 
     assert_eq!(actix_web::http::StatusCode::OK, res.status());
 
-    let url = format!(
-        "/api/projects/p/{}/data",
-        common::OVERWRITTEN_DATA_PROJECT_ID
-    );
+    let url = format!("/api/projects/{}/data", common::OVERWRITTEN_DATA_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header((
@@ -265,10 +256,10 @@ async fn only_one_dataset_can_be_added_to_a_project() -> Result<()> {
 
 #[actix_rt::test]
 async fn datasets_cannot_be_added_if_projects_do_not_exist() -> Result<()> {
-    let mut app = api_with! { put: "/api/projects/p/{project_id}/data" => projects::add_data };
+    let mut app = api_with! { put: "/api/projects/{project_id}/data" => projects::add_data };
 
     let doc = doc! {"content": "age,sex,location\n22,M,Leamington Spa", "name": "Freddie"};
-    let url = format!("/api/projects/p/{}/data", common::NON_EXISTENT_PROJECT_ID);
+    let url = format!("/api/projects/{}/data", common::NON_EXISTENT_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
         .insert_header((
@@ -288,12 +279,12 @@ async fn datasets_cannot_be_added_if_projects_do_not_exist() -> Result<()> {
 #[actix_rt::test]
 async fn dataset_can_be_taken_from_database() -> Result<()> {
     let mut app = api_with! {
-        get: "/api/projects/p/{project_id}/data" => projects::get_data,
-        put: "/api/projects/p/{project_id}/data" => projects::add_data,
+        get: "/api/projects/{project_id}/data" => projects::get_data,
+        put: "/api/projects/{project_id}/data" => projects::add_data,
     };
 
     let doc = doc! {"content": "age,sex,location\n22,M,Leamington Spa", "name": "Freddie"};
-    let url = format!("/api/projects/p/{}/data", common::MAIN_PROJECT_ID);
+    let url = format!("/api/projects/{}/data", common::MAIN_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -304,7 +295,7 @@ async fn dataset_can_be_taken_from_database() -> Result<()> {
     let res = test::call_service(&mut app, req).await;
     assert_eq!(actix_web::http::StatusCode::OK, res.status());
 
-    let url = format!("/api/projects/p/{}/data", common::MAIN_PROJECT_ID);
+    let url = format!("/api/projects/{}/data", common::MAIN_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -320,12 +311,12 @@ async fn dataset_can_be_taken_from_database() -> Result<()> {
 #[actix_rt::test]
 async fn overview_of_dataset_can_be_returned() -> Result<()> {
     let mut app = api_with! {
-        put: "/api/projects/p/{project_id}/data" => projects::add_data,
-        post: "/api/projects/p/{project_id}/overview" => projects::overview,
+        put: "/api/projects/{project_id}/data" => projects::add_data,
+        post: "/api/projects/{project_id}/overview" => projects::overview,
     };
 
     let doc = doc! {"content": "age,sex,location\n22,M,Leamington Spa", "name": "Freddie"};
-    let url = format!("/api/projects/p/{}/data", common::MAIN_PROJECT_ID);
+    let url = format!("/api/projects/{}/data", common::MAIN_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -336,7 +327,7 @@ async fn overview_of_dataset_can_be_returned() -> Result<()> {
     let res = test::call_service(&mut app, req).await;
     assert_eq!(actix_web::http::StatusCode::OK, res.status());
 
-    let url = format!("/api/projects/p/{}/overview", common::MAIN_PROJECT_ID);
+    let url = format!("/api/projects/{}/overview", common::MAIN_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::POST)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -352,11 +343,11 @@ async fn overview_of_dataset_can_be_returned() -> Result<()> {
 #[actix_rt::test]
 async fn projects_can_be_deleted() -> Result<()> {
     let mut app = api_with! {
-        delete: "/api/projects/p/{project_id}" => projects::delete_project,
-        post: "/api/projects/p/{project_id}/overview" => projects::overview,
+        delete: "/api/projects/{project_id}" => projects::delete_project,
+        post: "/api/projects/{project_id}/overview" => projects::overview,
     };
 
-    let formatted = format!("/api/projects/p/{}", common::DELETABLE_PROJECT_ID);
+    let formatted = format!("/api/projects/{}", common::DELETABLE_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::DELETE)
         .insert_header((
@@ -390,11 +381,11 @@ async fn projects_can_be_deleted() -> Result<()> {
 #[actix_rt::test]
 async fn projects_can_be_edited() -> Result<()> {
     let mut app = api_with! {
-        patch: "/api/projects/p/{project_id}" => projects::patch_project,
-        get: "/api/projects/p/{project_id}" => projects::get_project,
+        patch: "/api/projects/{project_id}" => projects::patch_project,
+        get: "/api/projects/{project_id}" => projects::get_project,
     };
 
-    let formatted = format!("/api/projects/p/{}", common::EDITABLE_PROJECT_ID);
+    let formatted = format!("/api/projects/{}", common::EDITABLE_PROJECT_ID);
     let doc = doc! {"changes": {"description": "new description"}};
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PATCH)
@@ -406,7 +397,7 @@ async fn projects_can_be_edited() -> Result<()> {
     let res = test::call_service(&mut app, req).await;
     assert_eq!(actix_web::http::StatusCode::OK, res.status());
 
-    let formatted = format!("/api/projects/p/{}", common::EDITABLE_PROJECT_ID);
+    let formatted = format!("/api/projects/{}", common::EDITABLE_PROJECT_ID);
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::GET)
         .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
@@ -425,12 +416,12 @@ async fn projects_can_be_edited() -> Result<()> {
 #[actix_rt::test]
 async fn job_configs_can_have_integer_timeouts_in_json() -> Result<()> {
     let mut app = api_with! {
-        put: "/api/projects/p/{project_id}/data" => projects::add_data,
-        post: "/api/projects/p/{project_id}/process" => projects::begin_processing,
+        put: "/api/projects/{project_id}/data" => projects::add_data,
+        post: "/api/projects/{project_id}/process" => projects::begin_processing,
     };
 
     let doc = doc! {"content": "age,sex,location\n22,M,Leamington Spa", "name": "Freddie"};
-    let url = format!("/api/projects/p/{}/data", common::MAIN_PROJECT_ID);
+    let url = format!("/api/projects/{}/data", common::MAIN_PROJECT_ID);
 
     let req = test::TestRequest::default()
         .method(actix_web::http::Method::PUT)
@@ -443,7 +434,7 @@ async fn job_configs_can_have_integer_timeouts_in_json() -> Result<()> {
 
     assert_eq!(actix_web::http::StatusCode::OK, res.status());
 
-    let formatted = format!("/api/projects/p/{}/process", common::MAIN_PROJECT_ID);
+    let formatted = format!("/api/projects/{}/process", common::MAIN_PROJECT_ID);
     let doc =
         doc! { "timeout": 10 , "predictionType": "classification", "predictionColumn": "name"};
     let req = test::TestRequest::default()

--- a/backend/dcl/src/protocol/mod.rs
+++ b/backend/dcl/src/protocol/mod.rs
@@ -88,7 +88,7 @@ impl<'a> Handler<'a> {
             "email": &email,
         });
 
-        let endpoint = "/api/clients/m/new";
+        let endpoint = "/api/clients/models/new";
         let text = get_response_text(endpoint, body).await?;
 
         let message = RawMessage::new(text);
@@ -119,7 +119,7 @@ impl<'a> Handler<'a> {
             "challenge_response": &response,
         });
 
-        let endpoint = "/api/clients/m/verify";
+        let endpoint = "/api/clients/models/verify";
         let text = get_response_text(endpoint, body).await?;
 
         let message = RawMessage::new(text);
@@ -144,7 +144,7 @@ impl<'a> Handler<'a> {
             "token": &token,
         });
 
-        let endpoint = format!("/api/clients/m/{}/authenticate", &id);
+        let endpoint = format!("/api/clients/models/{}/authenticate", &id);
         let text = get_response_text(&endpoint, body).await?;
 
         let message = RawMessage::new(text);

--- a/backend/dcl/src/protocol/tests.rs
+++ b/backend/dcl/src/protocol/tests.rs
@@ -14,7 +14,7 @@ async fn nodes_can_immediately_send_tokens() -> Result<(), Box<dyn Error>> {
     // Setup the API server mocking
     let authenticate = mock(
         "POST",
-        "/api/clients/m/5fe8b9d85511355cdab720aa/authenticate",
+        "/api/clients/models/5fe8b9d85511355cdab720aa/authenticate",
     )
     .with_status(200)
     .with_body(r#"{"message": "Authentication successful"}"#)
@@ -135,7 +135,7 @@ async fn protocol_cares_about_api_responses() -> Result<(), Box<dyn Error>> {
     // Setup the API server mocking, failing on the `authenticate` route
     let authenticate = mock(
         "POST",
-        "/api/clients/m/5fe8b9d85511355cdab720aa/authenticate",
+        "/api/clients/models/5fe8b9d85511355cdab720aa/authenticate",
     )
     .with_status(401)
     .create();

--- a/web/src/components/AddProject.vue
+++ b/web/src/components/AddProject.vue
@@ -142,7 +142,7 @@ export default {
     },
     async sendFile(e) {
       let project_response = await this.$http.put(
-        `http://localhost:3001/api/projects/p/${this.project_id}/data`,
+        `http://localhost:3001/api/projects/${this.project_id}/data`,
         {
           name: this.file.name,
           content: e.target.result,

--- a/web/src/components/ModelCard.vue
+++ b/web/src/components/ModelCard.vue
@@ -144,7 +144,7 @@ export default {
   async mounted() {
     try {
       let data = await this.$http.get(
-        `http://localhost:3001/api/clients/m/${this.data._id.$oid}/performance`,
+        `http://localhost:3001/api/clients/models/${this.data._id.$oid}/performance`,
       );
       this.performance = data.data;
     } catch (err) {
@@ -168,7 +168,7 @@ export default {
   methods: {
     async onSubmit() {
       let response = await this.$http.post(
-        `http://localhost:3001/api/clients/m/${this.data._id.$oid}/unlock`,
+        `http://localhost:3001/api/clients/models/${this.data._id.$oid}/unlock`,
         {
           password: this.password,
         }

--- a/web/src/components/ProjectOverview.vue
+++ b/web/src/components/ProjectOverview.vue
@@ -200,7 +200,7 @@ export default {
     async start() {
       try {
         await this.$http.post(
-          `http://localhost:3001/api/projects/p/${this.projectId}/process`,
+          `http://localhost:3001/api/projects/${this.projectId}/process`,
           {
             timeout: this.timeout,
             predictionType: this.problemType,
@@ -217,7 +217,7 @@ export default {
     async deleteDataset() {
       try {
         let project_response = await this.$http.delete(
-          `http://localhost:3001/api/projects/p/${this.projectId}/data`
+          `http://localhost:3001/api/projects/${this.projectId}/data`
         );
       } catch (err) {
         console.log(err);
@@ -233,7 +233,7 @@ export default {
     },
     async sendFile(e) {
       let project_response = await this.$http.put(
-        `http://localhost:3001/api/projects/p/${this.projectId}/data`,
+        `http://localhost:3001/api/projects/${this.projectId}/data`,
         {
           name: this.file.name,
           content: e.target.result,

--- a/web/src/components/ProjectSettings.vue
+++ b/web/src/components/ProjectSettings.vue
@@ -78,7 +78,7 @@ export default {
 
       try {
         let project_response = await this.$http.patch(
-          `http://localhost:3001/api/projects/p/${this.projectId}`,
+          `http://localhost:3001/api/projects/${this.projectId}`,
           {
             changes: {
               name: this.newName,
@@ -94,7 +94,7 @@ export default {
 
       try {
         let project_response = await this.$http.patch(
-          `http://localhost:3001/api/projects/p/${this.projectId}`,
+          `http://localhost:3001/api/projects/${this.projectId}`,
           {
             changes: {
               description: this.newDescription,
@@ -110,7 +110,7 @@ export default {
 
       try {
         let project_response = await this.$http.delete(
-          `http://localhost:3001/api/projects/p/${this.projectId}`
+          `http://localhost:3001/api/projects/${this.projectId}`
         );
       } catch (err) {
         console.log(err);

--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -111,7 +111,7 @@ export default {
   methods: {
     async fetchProject() {
       let project_response = await this.$http.get(
-        `http://localhost:3001/api/projects/p/${this.projectId}`
+        `http://localhost:3001/api/projects/${this.projectId}`
       );
 
       let project_details = project_response.data.details;
@@ -132,7 +132,7 @@ export default {
       this.loading = true;
 
       let project_response = await this.$http.get(
-        `http://localhost:3001/api/projects/p/${this.projectId}/data`
+        `http://localhost:3001/api/projects/${this.projectId}/data`
       );
 
       let project_data = project_response.data.dataset;
@@ -144,7 +144,7 @@ export default {
       this.results_loading = true;
 
       let project_predictions = await this.$http.get(
-        `http://localhost:3001/api/projects/p/${this.projectId}/predictions`
+        `http://localhost:3001/api/projects/${this.projectId}/predictions`
       );
       this.results = project_predictions.data["predictions"];
       this.predict_data = project_predictions.data["predict_data"];

--- a/web/src/views/Dashboard.vue
+++ b/web/src/views/Dashboard.vue
@@ -147,7 +147,7 @@ export default {
     },
     async addProject(id) {
       let project_response = await this.$http.get(
-        `http://localhost:3001/api/projects/p/${id}`
+        `http://localhost:3001/api/projects/${id}`
       );
 
       let x = project_response.data.project;

--- a/web/src/views/Nodes.vue
+++ b/web/src/views/Nodes.vue
@@ -138,7 +138,7 @@ export default {
     let user_id = $cookies.get("token");
     try {
       let data = await this.$http.get(
-        `http://localhost:3001/api/clients`
+        `http://localhost:3001/api/clients/models`
       );
       this.model_data = data.data;
     } catch (err) {


### PR DESCRIPTION
Rename most of the API routes to remove some of the fluff. This changes both the backend and frontend so in theory should remain identical, however there is so much code that parsing with regular expressions may have missed one or two.

Fixes #282.
