### PR TITLE
Allow models to be unlocked on the frontend

### DIFF
--- a/web/src/components/ModelCard.vue
+++ b/web/src/components/ModelCard.vue
@@ -82,7 +82,7 @@
               </h1>
               <b-card-title>Unlock Model</b-card-title>
               <b-card-text>Please provide your password to confirm</b-card-text>
-              <b-form class="mt-5 mb-3" @submit="onSubmit">
+              <b-form class="mt-5 mb-3" @submit.prevent="onSubmit">
                 <b-form-input
                   type="password"
                   id="name"


### PR DESCRIPTION
This seems to allow models to be unlocked when using the frontend instead of sending a raw request through CURL. Previously, Vue would display error messages about not sending the request in the console and not actually send a request.

This comes with the caveat that the page does not reload after the request is sent, but users can refresh the page for now.

Closes #201, #248.
