### PR TITLE
Fix API server requests and ban Atlas tests

### DIFF
--- a/backend/dcl/src/protocol/mod.rs
+++ b/backend/dcl/src/protocol/mod.rs
@@ -84,7 +84,7 @@ impl<'a> Handler<'a> {
 
         // Query the API server
         let body = bson!({
-            "model_name": &model_name,
+            "modelName": &model_name,
             "email": &email,
         });
 
@@ -114,9 +114,9 @@ impl<'a> Handler<'a> {
 
         // Query the API server
         let body = bson!({
-            "model_name": &model_name,
+            "modelName": &model_name,
             "email": &email,
-            "challenge_response": &response,
+            "challengeResponse": &response,
         });
 
         let endpoint = "/api/clients/models/verify";

--- a/backend/dcl/tests/common.rs
+++ b/backend/dcl/tests/common.rs
@@ -52,6 +52,13 @@ pub async fn initialise_with_db() -> (Database, Params) {
     let mut lock = MUTEX.lock().await;
 
     let params = initialise();
+
+    // Ensure that we aren't using the Atlas instance
+    assert!(
+        !params.conn_str.starts_with("mongodb+srv"),
+        "Please setup a local MongoDB instance for running the tests"
+    );
+
     let client = mongodb::Client::with_uri_str(&params.conn_str)
         .await
         .unwrap();


### PR DESCRIPTION
Fix the API server requests (that have been broken for a while, since merging #271 I believe) and ban running tests on Atlas, as this caused the production database to be wiped a couple days ago.
