### PR TITLE
feat: make JWT keys secret in production

### DIFF
--- a/backend/api-server/src/auth/mod.rs
+++ b/backend/api-server/src/auth/mod.rs
@@ -10,15 +10,19 @@ use mongodb::bson::oid::ObjectId;
 
 use crate::error::ServerError;
 
+#[cfg(debug_assertions)]
+const KEY: &[u8] = include_bytes!("../../jwt_key");
+
+#[cfg(not(debug_assertions))]
+const KEY: &[u8] = include_bytes!("../../prod_jwt_key");
+
 /// Retrieves the encoding key used for JWT authentication.
 pub fn get_encoding_key() -> EncodingKey {
-    let key = include_str!("../../jwt_key");
-    EncodingKey::from_secret(&key.as_bytes())
+    EncodingKey::from_secret(KEY)
 }
 
 fn get_decoding_key() -> DecodingKey<'static> {
-    let key = include_str!("../../jwt_key");
-    DecodingKey::from_secret(&key.as_bytes())
+    DecodingKey::from_secret(KEY)
 }
 
 /// The claims made by a user for authentication.


### PR DESCRIPTION
When building a development version of the API server, use the existing `jwt_key` which is committed to the repository. When building in release mode for production, use a different file that is not tied to Git. This causes no existing changes to development workflows, but forces the server to use a different key.

Closes #209.
