### PR TITLE
tests: fix the multipart upload tests

### DIFF
--- a/backend/api-server/tests/assets/asl.csv
+++ b/backend/api-server/tests/assets/asl.csv
@@ -1,0 +1,7 @@
+--boundary
+Content-Disposition: form-data; filename="asl.csv"
+
+age,sex,location
+23,M,Leamington Spa
+22,F,
+--boundary--


### PR DESCRIPTION
Add an asset called `asl.csv` that contains a multipart formatted CSV
file that can be uploaded during tests. This is formatted with DOS line
endings (`\r\n`) as this is what the library expects.

Test requests can then use this file as their payload and set the
`Content-Type` to `form/multipart` to correctly upload the data.