### PR TITLE
feat: add basic email notifications

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -434,6 +434,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +809,7 @@ dependencies = [
  "futures",
  "http",
  "httparse",
+ "lettre",
  "log",
  "messages",
  "mockito",
@@ -974,6 +987,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futf"
@@ -1308,6 +1327,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperx"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82566a1ace7f56f604d83b7b2c259c78e243d99c565f23d7b4ae34466442c5a2"
+dependencies = [
+ "base64 0.13.0",
+ "bytes",
+ "http",
+ "httparse",
+ "httpdate",
+ "language-tags",
+ "mime",
+ "percent-encoding",
+ "unicase",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1437,32 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lettre"
+version = "0.10.0-beta.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897171ed0e63da84c988b157106ad8b6532d7499aeeec906ce46b05415cc79d3"
+dependencies = [
+ "async-trait",
+ "base64 0.13.0",
+ "futures-io",
+ "futures-util",
+ "hostname",
+ "hyperx",
+ "idna",
+ "mime",
+ "native-tls",
+ "nom",
+ "once_cell",
+ "quoted_printable",
+ "r2d2",
+ "rand 0.8.3",
+ "regex",
+ "tokio",
+ "tokio-native-tls",
+ "uuid",
+]
 
 [[package]]
 name = "libc"
@@ -1680,6 +1742,18 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
+ "memchr",
+ "version_check",
+]
 
 [[package]]
 name = "ntapi"
@@ -2046,6 +2120,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "quoted_printable"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1238256b09923649ec89b08104c4dfe9f6cb2fea734a5db5384e44916d59e9c5"
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +2413,15 @@ checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]
@@ -2710,6 +2816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,6 +3407,12 @@ checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "xml5ever"

--- a/backend/dcl/Cargo.toml
+++ b/backend/dcl/Cargo.toml
@@ -38,3 +38,7 @@ mockito = "0.30.0"
 [dependencies.reqwest]
 version = "0.11.2"
 features = ["json"]
+
+[dependencies.lettre]
+version = "0.10.0-beta.3"
+features = ["smtp-transport", "tokio1", "tokio1-native-tls"]

--- a/backend/dcl/src/job_end/mod.rs
+++ b/backend/dcl/src/job_end/mod.rs
@@ -1,20 +1,23 @@
 //! Part of DCL that takes a DCN and a dataset and comunicates with node
 
-use bytes::Bytes;
-use rand::seq::SliceRandom;
-use rand::{thread_rng, Rng};
 use std::cmp::max;
 use std::collections::HashMap;
 use std::convert::From;
+use std::env;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
+use bytes::Bytes;
+use lettre::transport::smtp::authentication::Credentials;
+use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
 use mongodb::{
-    bson::{doc, oid::ObjectId},
+    bson::{doc, from_document, oid::ObjectId},
     Database,
 };
+use rand::seq::SliceRandom;
+use rand::{thread_rng, Rng};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::sync::{Notify, RwLock};
@@ -27,7 +30,8 @@ use models::gridfs;
 use models::jobs::JobConfiguration;
 use models::jobs::PredictionType;
 use models::predictions::Prediction;
-use models::projects::Status;
+use models::projects::{Project, Status};
+use models::users::User;
 
 use utils::anon::{anonymise_dataset, deanonymise_dataset, infer_dataset_columns};
 use utils::compress::compress_data;
@@ -134,6 +138,28 @@ impl ClusterControl {
         if *write_cc == 0 {
             self.notify.notify_one();
         }
+    }
+}
+
+/// The configuration for sending emails.
+#[derive(Debug)]
+pub struct Config {
+    /// The address to send from.
+    pub from_address: String,
+    /// The name to send from.
+    pub from_name: String,
+    /// The application specific password for Gmail.
+    pub app_password: String,
+}
+
+impl Config {
+    /// Builds a configuration from the environment variables.
+    pub fn from_env() -> Result<Self, std::env::VarError> {
+        Ok(Self {
+            from_address: env::var("FROM_ADDRESS")?,
+            from_name: env::var("FROM_NAME")?,
+            app_password: env::var("APP_PASSWORD")?,
+        })
     }
 }
 
@@ -486,7 +512,17 @@ async fn run_cluster(
         .await
         .unwrap_or_else(|error| log::error!("Error writing predictions to DB: {}", error));
 
-    change_status(database, project_id, Status::Complete).await?;
+    change_status(&database, &project_id, Status::Complete).await?;
+
+    // Status has been updated to complete, so email the user
+    if let Err(e) = email_user_on_project_finish(&database, &project_id).await {
+        log::warn!(
+            "Failed to email the user upon finishing processing of project_id={}: {}",
+            project_id,
+            e
+        );
+    }
+
     Ok(())
 }
 
@@ -603,19 +639,83 @@ pub async fn increment_run_count(database: Arc<Database>, model_id: &str) -> Res
 
 /// Change the status of a project after it has been completed
 pub async fn change_status(
-    database: Arc<Database>,
-    project_id: ObjectId,
+    database: &Arc<Database>,
+    project_id: &ObjectId,
     status: Status,
 ) -> Result<()> {
     let projects = database.collection("projects");
 
     projects
         .update_one(
-            doc! { "_id": &project_id},
+            doc! { "_id": project_id},
             doc! {"$set": {"status": status}},
             None,
         )
         .await?;
+
+    Ok(())
+}
+
+/// Emails the user to inform them the project has finished.
+///
+/// If any of the appropriate environment variables are not set (being the `FROM_ADDRESS`,
+/// `FROM_NAME` and `APP_PASSWORD`), no emails will sent. Otherwise, this will retrieve the project
+/// information from the database and the user who created it, before formatting an email and
+/// sending it to them. This is currently hardcoded to use Google's mail servers and is largely
+/// based on similar code that runs the email system for `blackboards.pl`.
+pub async fn email_user_on_project_finish(
+    database: &Arc<Database>,
+    project_id: &ObjectId,
+) -> Result<()> {
+    let users = database.collection("users");
+    let projects = database.collection("projects");
+
+    // Find the project itself and convert it
+    let document = projects
+        .find_one(doc! { "_id": &project_id }, None)
+        .await?
+        .expect("Project did not exist in the database");
+
+    let project = from_document::<Project>(document)?;
+
+    // Find the user associated with the project and deserialize it
+    let user_document = users
+        .find_one(doc! { "_id": &project.user_id }, None)
+        .await?
+        .expect("Failed to find user associated with project");
+
+    let user: User = from_document(user_document)?;
+
+    // Get the configuration from the environment if it exists
+    let email_config = Config::from_env()?;
+
+    // Form the sender and receiver addresses, as well as the body
+    let from = format!("{} <{}>", email_config.from_name, email_config.from_address);
+    let to = format!("{} {} <{}>", user.first_name, user.last_name, user.email);
+    let body = format!(
+        r#"Hi {},
+
+Your project '{}' has finished processing, and results are now available. You can view them at https://sybl.tech/dashboard/{}"#,
+        user.first_name, project.name, project_id
+    );
+
+    // Build the message to send
+    let email = Message::builder()
+        .from(from.parse()?)
+        .to(to.parse()?)
+        .subject("Sybl Project Completion")
+        .body(body)?;
+
+    // Use the credentials from the configuration parsed earlier
+    let creds = Credentials::new(email_config.from_address, email_config.app_password);
+
+    // Open a remote connection to gmail
+    let mailer = AsyncSmtpTransport::<Tokio1Executor>::relay("smtp.gmail.com")?
+        .credentials(creds)
+        .build();
+
+    // Send the email itself
+    mailer.send(email).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Add basic email notifications when a user's job finishes. This simply sends them an email saying their project has finished processing and that they can check the results, linking them to the production website.

In the future, we might want this to be better formatted as currently it is just some basic text. For the moment however, this looks like it may be more work than it is worth if we decide there are more pressing issues. I've opened #339 to track this.

Closes #327.
