### PR TITLE
fix: show an error on failed login

### DIFF
--- a/web/src/views/Login.vue
+++ b/web/src/views/Login.vue
@@ -98,19 +98,23 @@ export default {
     async onSubmit() {
       this.submitted = true;
 
-      let response = await this.$store.dispatch("login", {
-        email: this.email,
-        password: this.password,
-      });
+      try {
+        let response = await this.$store.dispatch("login", {
+          email: this.email,
+          password: this.password,
+        });
 
-      $cookies.set("token", response.data.token, {
-        path: "/",
-        sameSite: true,
-      });
+        $cookies.set("token", response.data.token, {
+          path: "/",
+          sameSite: true,
+        });
 
-      this.$router.push("dashboard");
-      this.failed = true;
-      this.submitted = false;
+        this.$router.push("dashboard");
+      } catch (error) {
+        console.debug("Invalid details when logging in a user");
+        this.failed = true;
+        this.submitted = false;
+      }
     },
   },
 };


### PR DESCRIPTION
When users fail to login, show an error below the form to tell them they had invalid credentials. This was broken as the Axios request would throw an error on a 401, meaning the later code would not be reached.

Instead, we can simply use a `try catch` statement to handle the error correctly and show the tooltip.

Fixes #381.
