### PR TITLE
feat: add a route to get the current job

### DIFF
--- a/backend/api-server/src/lib.rs
+++ b/backend/api-server/src/lib.rs
@@ -151,6 +151,10 @@ pub async fn build_server() -> Result<actix_web::dev::Server> {
                 "/api/projects/{project_id}/process",
                 web::post().to(routes::projects::begin_processing),
             )
+            .route(
+                "/api/projects/{project_id}/job",
+                web::post().to(routes::projects::currently_running_job),
+            )
             // Clients
             .route(
                 "/api/clients/register",

--- a/backend/api-server/tests/projects.rs
+++ b/backend/api-server/tests/projects.rs
@@ -5,9 +5,9 @@ use serde::{Deserialize, Serialize};
 use tokio::time::{sleep, Duration};
 
 use api_server::routes::projects;
-use models::dataset_analysis::DatasetAnalysis;
 use models::dataset_details::DatasetDetails;
 use models::projects::Project;
+use models::{dataset_analysis::DatasetAnalysis, jobs::Job};
 
 #[macro_use]
 mod common;
@@ -48,7 +48,7 @@ async fn projects_can_be_fetched_for_a_user() -> Result<()> {
 
     let projects: Vec<ProjectResponse> = test::read_body_json(res).await;
 
-    assert_eq!(projects.len(), 3);
+    assert_eq!(projects.len(), 4);
 
     let found = &projects[0];
 
@@ -636,6 +636,80 @@ async fn users_cannot_submit_jobs_with_insufficient_funds() -> Result<()> {
     let res = test::call_service(&mut app, req).await;
 
     assert_eq!(actix_web::http::StatusCode::PAYMENT_REQUIRED, res.status());
+
+    Ok(())
+}
+
+#[actix_rt::test]
+async fn recent_jobs_can_be_found() -> Result<()> {
+    let mut app = api_with! {
+        get: "/api/projects/{project_id}/job" => projects::currently_running_job,
+    };
+
+    let url = format!("/api/projects/{}/job", common::MAIN_PROJECT_ID);
+
+    let req = test::TestRequest::default()
+        .method(actix_web::http::Method::GET)
+        .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
+        .uri(&url)
+        .to_request();
+
+    let res = test::call_service(&mut app, req).await;
+    assert_eq!(actix_web::http::StatusCode::OK, res.status());
+
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentJobResponse {
+    job: Option<Job>,
+}
+
+#[actix_rt::test]
+async fn most_recent_job_is_returned() -> Result<()> {
+    let mut app = api_with! {
+        get: "/api/projects/{project_id}/job" => projects::currently_running_job,
+    };
+
+    let url = format!("/api/projects/{}/job", common::MAIN_PROJECT_ID);
+
+    let req = test::TestRequest::default()
+        .method(actix_web::http::Method::GET)
+        .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
+        .uri(&url)
+        .to_request();
+
+    let res = test::call_service(&mut app, req).await;
+    assert_eq!(actix_web::http::StatusCode::OK, res.status());
+
+    // Verify the response was correct
+    let body: RecentJobResponse = test::read_body_json(res).await;
+    assert!(body.job.is_some());
+
+    Ok(())
+}
+
+#[actix_rt::test]
+async fn no_jobs_are_returned_if_all_are_processed() -> Result<()> {
+    let mut app = api_with! {
+        get: "/api/projects/{project_id}/job" => projects::currently_running_job,
+    };
+
+    let url = format!("/api/projects/{}/job", common::PROCESSED_JOBS_PROJECT_ID);
+
+    let req = test::TestRequest::default()
+        .method(actix_web::http::Method::GET)
+        .insert_header(("Authorization", get_bearer_token(common::MAIN_USER_ID)))
+        .uri(&url)
+        .to_request();
+
+    let res = test::call_service(&mut app, req).await;
+    assert_eq!(actix_web::http::StatusCode::OK, res.status());
+
+    // Verify the response was correct
+    let body: RecentJobResponse = test::read_body_json(res).await;
+    assert!(body.job.is_none());
 
     Ok(())
 }

--- a/backend/dcl/src/interface_end/mod.rs
+++ b/backend/dcl/src/interface_end/mod.rs
@@ -104,20 +104,21 @@ async fn process_job(
     job_config: JobConfiguration,
 ) -> Result<()> {
     let JobConfiguration {
-        dataset_id,
+        project_id,
         node_computation_time,
         ..
     } = job_config.clone();
 
     log::debug!(
-        "Received a job to process: dataset_id={}, node_computation_time={}",
-        dataset_id,
+        "Received a job to process: project_id={}, node_computation_time={}",
+        project_id,
         node_computation_time,
     );
 
     let datasets = db_conn.collection("datasets");
 
-    let filter = doc! { "_id": dataset_id };
+    // Query the dataset currently associated with the project
+    let filter = doc! { "project_id": &project_id };
 
     let doc = datasets
         .find_one(filter, None)

--- a/backend/dcl/tests/job.rs
+++ b/backend/dcl/tests/job.rs
@@ -94,7 +94,7 @@ fn test_evaluate_model() {
         project_id: ObjectId::with_string(common::USER_ID).unwrap(),
         columns: HashMap::new(),
         config: JobConfiguration {
-            dataset_id: ObjectId::new(),
+            project_id: ObjectId::new(),
             node_computation_time: 0,
             cluster_size: 3,
             column_types: vec![],
@@ -178,7 +178,7 @@ fn test_weight_predictions() {
         project_id: ObjectId::with_string(common::USER_ID).unwrap(),
         columns: HashMap::new(),
         config: JobConfiguration {
-            dataset_id: ObjectId::new(),
+            project_id: ObjectId::new(),
             node_computation_time: 0,
             cluster_size: 3,
             column_types: vec![],
@@ -217,7 +217,7 @@ fn test_weight_predictions() {
         project_id: ObjectId::with_string(common::USER_ID).unwrap(),
         columns: HashMap::new(),
         config: JobConfiguration {
-            dataset_id: ObjectId::new(),
+            project_id: ObjectId::new(),
             node_computation_time: 0,
             cluster_size: 3,
             column_types: vec![],

--- a/backend/models/src/jobs.rs
+++ b/backend/models/src/jobs.rs
@@ -18,8 +18,8 @@ pub enum PredictionType {
 /// Parameters required for configuring a job.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct JobConfiguration {
-    /// The identifier of the dataset to be processed
-    pub dataset_id: ObjectId,
+    /// The identifier of the project to be processed
+    pub project_id: ObjectId,
     /// The amount of time each node is allowed to compute for
     pub node_computation_time: i32,
     /// The cluster size for a job


### PR DESCRIPTION
Add a route that gets the current job for a given project. This will query the database for all the jobs related to that project and take the most recent one. If the project has no jobs that haven't been processed, nothing will be returned.
