### PR TITLE
fix: grey out tabs when project status is undefined

### DIFF
--- a/web/src/components/ProjectView.vue
+++ b/web/src/components/ProjectView.vue
@@ -127,7 +127,8 @@ export default {
   },
   computed: {
     projectUnfinished() {
-      return this.project_status == "unfinished";
+      console.log(this.project_status);
+      return (this.project_status == "unfinished") || (this.project_status == undefined);
     },
     projectComplete() {
       return this.project_status != "complete";


### PR DESCRIPTION
Fixes issue where tabs are not greyed out when the project is created becasue the project status is undefined.