### PR TITLE
feat: allow jobs to be marked as processed

### DIFF
--- a/backend/api-server/src/routes/projects.rs
+++ b/backend/api-server/src/routes/projects.rs
@@ -1239,7 +1239,7 @@ pub async fn begin_processing(
     // Insert to MongoDB first, so the interface can immediately mark as processed if needed
     insert_to_queue(&job, state.database.collection("jobs")).await?;
 
-    let job_message = serde_json::to_string(&job.config).unwrap();
+    let job_message = serde_json::to_string(&job).unwrap();
     let job_key = &job.id.to_string();
     let topic = "jobs";
 

--- a/backend/dcl/src/job_end/ml.rs
+++ b/backend/dcl/src/job_end/ml.rs
@@ -41,7 +41,7 @@ pub fn weight_predictions(
     let mut indexes: Vec<&usize> = test_examples.into_iter().collect();
     indexes.sort();
 
-    let job_type = info.config.prediction_type;
+    let job_type = info.job.config.prediction_type;
 
     let mut predictions: Vec<String> = Vec::new();
     predictions.push(String::from("predicted"));
@@ -100,7 +100,7 @@ pub fn evaluate_model(
     let mut model_error: f64 = 1.0;
     let mut model_predictions: Predictions = HashMap::new();
 
-    let job_type = info.config.prediction_type;
+    let job_type = info.job.config.prediction_type;
 
     let mut predictions: Vec<_> = predictions.trim().split('\n').collect();
 


### PR DESCRIPTION
When jobs complete in the DCL, mark them as processed in the database.  This requires the entire job to be used throughout the DCL, but doesn't change much else. The API server also now sends the whole job and the DCL expects this.

Closes #396.
