### PR TITLE
fix: only show stats for unlocked models

### DIFF
--- a/web/src/components/ModelCard.vue
+++ b/web/src/components/ModelCard.vue
@@ -16,7 +16,7 @@
                 <b-card-title>
                   {{ model.name }}
                 </b-card-title>
-                <b-card-text>
+                <b-card-text v-if="model.locked == false">
                   <b-icon-clock-fill></b-icon-clock-fill>
                   {{ model.processing_time_secs }}s total processing
                 </b-card-text>
@@ -51,7 +51,7 @@
                   ></b-icon-exclamation-triangle-fill>
                   Error
                 </b-card-text>
-                <b-card-text>
+                <b-card-text v-if="model.locked == false">
                   <b-icon-cash-stack></b-icon-cash-stack>
                   {{ model.credits_earned }} credit(s) earned
                 </b-card-text>


### PR DESCRIPTION
When displaying model cards, only show the total processing time and credits earned for models that are unlocked.

Closes #406.
