### PR TITLE
fix: delete models if they fail challenge response

### DIFF
--- a/backend/api-server/src/routes/clients.rs
+++ b/backend/api-server/src/routes/clients.rs
@@ -219,7 +219,13 @@ pub async fn verify_challenge(
     let challenge_response = base64::decode(&payload.challenge_response)?;
 
     if !crypto::verify_challenge(&challenge, &challenge_response, &public_key) {
-        log::warn!("Provided challenge did not match expected");
+        log::warn!(
+            "Provided challenge did not match expected, deleting model_id={}",
+            model.id
+        );
+
+        models.delete_one(filter, None).await?;
+
         return Err(ServerError::Unauthorized);
     }
 


### PR DESCRIPTION
If a client fails their challenge response, delete the model associated with it. As clients are expected to make a request to create the model and then immediately perform a challenge response, this means that they will not see the model on the frontend in a weird state.

This will need some follow-up changes most likely, as clients are not informed of why they failed the challenge verification (or in-fact, that it happened at all). However, this will require a lot more work post-UAT as the DCL-Mallus protocol will need to be upgraded with better error handling.

Closes #353.
