### PR TITLE
Return 404 if user not found

### DIFF
--- a/backend/api-server/src/routes/users.rs
+++ b/backend/api-server/src/routes/users.rs
@@ -24,7 +24,10 @@ pub async fn get(claims: auth::Claims, state: web::Data<State>) -> ServerRespons
     let users = state.database.collection("users");
 
     let filter: Document = doc! { "_id": claims.id };
-    let document = users.find_one(filter, None).await?;
+    let document = users
+        .find_one(filter, None)
+        .await?
+        .ok_or(ServerError::NotFound)?;
 
     response_from_json(document)
 }

--- a/web/src/services/axios-instance.js
+++ b/web/src/services/axios-instance.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import store from "../store";
 
 const $http = axios.create({
   baseURL: process.env.VUE_APP_AXIOS_BASE || "http://localhost:3001",
@@ -10,10 +11,13 @@ $http.interceptors.request.use(function(config) {
   return config;
 });
 
-axios.interceptors.response.use(undefined, function(error) {
+$http.interceptors.response.use(undefined, function(error) {
   if (error) {
     const originalRequest = error.config;
-    if (error.response.status === 401 && !originalRequest._retry) {
+    if (
+      (error.response.status === 401 && !originalRequest._retry) ||
+      (originalRequest.url === "api/users" && error.response.status === 404)
+    ) {
       originalRequest._retry = true;
       store.dispatch("logout");
       return router.push("/login");


### PR DESCRIPTION
If a user is not found from route `api/users` return 404
On front end if the request is made to `api/users` and error code is 404 logout
and redirect them to login page