### PR TITLE
chore: add more logging

### DIFF
--- a/backend/api-server/src/routes/projects.rs
+++ b/backend/api-server/src/routes/projects.rs
@@ -392,12 +392,7 @@ pub async fn upload_train_and_predict(
     // Inform the analysis server of the new job
     let analytics_job = serde_json::to_string(&object_id).unwrap();
     let topic = "analytics";
-    if produce_message(&analytics_job, &analytics_job, &topic)
-        .await
-        .is_err()
-    {
-        log::warn!("Failed to forward object_id={} to Kafka", object_id);
-    }
+    produce_message(&analytics_job, &analytics_job, &topic).await;
 
     let (analysis_doc, details_doc) = get_all_project_info(&object_id, &state.database).await?;
     let mut response = doc! {"project": project_doc};
@@ -609,12 +604,7 @@ pub async fn upload_and_split(
     // Inform the analysis server of the new job
     let analytics_job = serde_json::to_string(&object_id).unwrap();
     let topic = "analytics";
-    if produce_message(&analytics_job, &analytics_job, &topic)
-        .await
-        .is_err()
-    {
-        log::warn!("Failed to forward object_id={} to Kafka", object_id);
-    }
+    produce_message(&analytics_job, &analytics_job, &topic).await;
 
     let (analysis_doc, details_doc) = get_all_project_info(&object_id, &state.database).await?;
     let mut response = doc! {"project": project_doc};
@@ -630,12 +620,7 @@ pub async fn upload_and_split(
     // Communicate with Analytics Server
     let analytics_job = serde_json::to_string(&object_id).unwrap();
     let topic = "analytics";
-    if produce_message(&analytics_job, &analytics_job, &topic)
-        .await
-        .is_err()
-    {
-        log::warn!("Failed to forward object_id={} to Kafka", object_id);
-    }
+    produce_message(&analytics_job, &analytics_job, &topic).await;
 
     response_from_json(response)
 }
@@ -1247,12 +1232,7 @@ pub async fn begin_processing(
     let job_key = &job.id.to_string();
     let topic = "jobs";
 
-    if produce_message(&job_message, job_key, &topic)
-        .await
-        .is_err()
-    {
-        log::warn!("Failed to forward job_id={} to Kafka", job.id);
-    }
+    produce_message(&job_message, job_key, &topic).await;
 
     // Delete previous predictions for project
     let filter = doc! {"project_id": &object_id};

--- a/backend/dcl/src/health/tests.rs
+++ b/backend/dcl/src/health/tests.rs
@@ -23,7 +23,7 @@ async fn test_heartbeat() -> Result<(), Box<dyn Error>> {
     tokio::time::sleep(Duration::from_millis(1)).await;
 
     let stream = TcpStream::connect(addr).await.unwrap();
-    let verdict = heartbeat(Arc::new(RwLock::new(stream))).await;
+    let verdict = heartbeat("", Arc::new(RwLock::new(stream))).await;
 
     assert_eq!(verdict, true);
 
@@ -50,7 +50,7 @@ async fn test_heartbeat_fail() -> Result<(), Box<dyn Error>> {
     let stream = TcpStream::connect(addr).await.unwrap();
 
     tokio::time::sleep(Duration::from_millis(3)).await;
-    let verdict = heartbeat(Arc::new(RwLock::new(stream))).await;
+    let verdict = heartbeat("", Arc::new(RwLock::new(stream))).await;
 
     assert_eq!(verdict, false);
 

--- a/backend/dcl/src/job_end/mod.rs
+++ b/backend/dcl/src/job_end/mod.rs
@@ -605,6 +605,13 @@ pub async fn dcl_protocol(
 
     // Stop the timer and record how long was spent processing
     let processing_time_secs = (Instant::now() - start).as_secs();
+    log::trace!(
+        "model_id={} spent {:?} processing {} training bytes and {} predictions bytes",
+        model_id,
+        processing_time_secs,
+        train.len(),
+        predict.len()
+    );
 
     // Ensure it is the right message and decode + decompress it
     let anonymised_predictions = match prediction_message {
@@ -667,12 +674,7 @@ pub async fn dcl_protocol(
     let message_key = project.user_id.to_string();
     let topic = "project_updates";
 
-    if kafka_message::produce_message(&message, &message_key, &topic)
-        .await
-        .is_err()
-    {
-        log::warn!("Failed to forward model_id={} to Kafka", &model_id);
-    }
+    kafka_message::produce_message(&message, &message_key, &topic).await;
 
     Ok(())
 }

--- a/backend/dcl/src/main.rs
+++ b/backend/dcl/src/main.rs
@@ -4,6 +4,7 @@ fn main() {
     let filters = vec![
         ("dcl", log::LevelFilter::Debug),
         ("config", log::LevelFilter::Debug),
+        ("messages", log::LevelFilter::Debug),
         ("models", log::LevelFilter::Debug),
         ("utils", log::LevelFilter::Debug),
     ];


### PR DESCRIPTION
Add more logging through the DCL, mostly at the `trace` level to allow for more fine-grained viewing of the system. This includes logging for the amount of time taken to respond to heartbeat messages, which may help in finding a good solution for #433.
