### PR TITLE
feat: add nicer error messages

### DIFF
--- a/backend/dcl/src/node_end/mod.rs
+++ b/backend/dcl/src/node_end/mod.rs
@@ -423,11 +423,11 @@ pub async fn run(nodepool: Arc<NodePool>, database: Arc<Database>, port: u16) ->
 
         log::info!("Node Connection: {}", inbound.peer_addr()?);
 
-        tokio::spawn(async move {
-            process_connection(inbound, db_clone, sp_clone)
-                .await
-                .unwrap();
-        });
+        let fut = process_connection(inbound, db_clone, sp_clone);
+
+        if let Err(e) = tokio::spawn(async move { fut.await }).await? {
+            log::error!("Error processing connection: {:?}", e);
+        }
     }
 
     Ok(())

--- a/backend/dcl/src/protocol/mod.rs
+++ b/backend/dcl/src/protocol/mod.rs
@@ -1,17 +1,74 @@
 //! Encodes the protocol for handling node connections in the DCL.
 
-use std::fmt::Display;
+use std::fmt::{self, Debug};
 
-use anyhow::{anyhow, Result};
 use mongodb::bson::bson;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
-use messages::{ClientMessage, RawMessage, ReadLengthPrefix};
+use messages::{ClientMessage, RawMessage, ReadLengthPrefix, WriteLengthPrefix};
 
 #[cfg(test)]
 mod tests;
+
+/// Errors that can occur during handling.
+#[derive(Debug, Serialize)]
+pub enum HandlerError {
+    /// An error occurred in the stream itself.
+    Stream,
+    /// An error occurred when sending something with [`reqwest`].
+    Reqwest {
+        /// The formatted error from [`reqwest`].
+        error: String,
+    },
+    /// The API server responded with an error.
+    Server {
+        /// The response status code.
+        code: u16,
+    },
+}
+
+impl HandlerError {
+    async fn handle(&self, stream: &mut TcpStream) -> std::io::Result<()> {
+        log::error!("Error occurred during handling: {:?}", self);
+
+        // If there was a stream error, we can't send anything to the client
+        if let Self::Stream = self {
+            return Ok(());
+        }
+
+        stream.write_all(&self.as_bytes()).await
+    }
+}
+
+impl fmt::Display for HandlerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Stream => write!(f, "stream error"),
+            Self::Reqwest { error } => write!(f, "{}", error),
+            Self::Server { code } => write!(f, "API server returned status={}", code),
+        }
+    }
+}
+
+impl std::error::Error for HandlerError {}
+
+impl From<std::io::Error> for HandlerError {
+    fn from(_err: std::io::Error) -> Self {
+        Self::Stream
+    }
+}
+
+impl From<reqwest::Error> for HandlerError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::Reqwest {
+            error: error.to_string(),
+        }
+    }
+}
+
+type HandlerResult<T> = std::result::Result<T, HandlerError>;
 
 /// The internal state for the protocol.
 #[derive(Debug)]
@@ -32,7 +89,7 @@ impl<'a> Handler<'a> {
     }
 
     /// Peeks at the current message in the channel.
-    async fn peek_message(&mut self) -> Result<&ClientMessage> {
+    async fn peek_message(&mut self) -> HandlerResult<&ClientMessage> {
         if self.current_msg.is_none() {
             let msg = self.read_message().await?;
             self.current_msg = Some(msg);
@@ -42,8 +99,8 @@ impl<'a> Handler<'a> {
     }
 
     /// Responds to a user and waits for their next message.
-    async fn respond(&mut self, bytes: &[u8]) -> Result<()> {
-        self.stream.write(bytes).await?;
+    async fn respond(&mut self, bytes: &[u8]) -> HandlerResult<()> {
+        self.stream.write_all(bytes).await?;
 
         let next = self.read_message().await?;
         self.current_msg = Some(next);
@@ -52,8 +109,10 @@ impl<'a> Handler<'a> {
     }
 
     /// Reads a [`Message`] from the TCP stream.
-    async fn read_message(&mut self) -> Result<ClientMessage> {
-        ClientMessage::from_stream(&mut self.stream, &mut self.buffer).await
+    async fn read_message(&mut self) -> HandlerResult<ClientMessage> {
+        ClientMessage::from_stream(&mut self.stream, &mut self.buffer)
+            .await
+            .map_err(|_| HandlerError::Stream)
     }
 
     /// Gets the access token for the user.
@@ -61,7 +120,18 @@ impl<'a> Handler<'a> {
     /// Begins the protocol either by getting a [`Message::NewModel`] and setting up the model for
     /// them along with the challenge response, or by instantly receiving a [`Message::AccessToken`]
     /// from the user.
-    pub async fn get_access_token(&mut self) -> Result<Option<(String, String)>> {
+    pub async fn get_access_token(&mut self) -> HandlerResult<Option<(String, String)>> {
+        let outcome = self.get_access_token_or_error().await;
+
+        if let Err(err) = outcome.as_ref() {
+            err.handle(&mut self.stream).await?;
+        }
+
+        outcome
+    }
+
+    /// Wrapper method that tries to get the user's access token.
+    async fn get_access_token_or_error(&mut self) -> HandlerResult<Option<(String, String)>> {
         if let ClientMessage::NewModel { .. } = self.peek_message().await? {
             self.register_new_model().await?;
             self.authenticate_challenge_response().await?;
@@ -74,7 +144,7 @@ impl<'a> Handler<'a> {
     }
 
     /// Registers a new model with the API server.
-    async fn register_new_model(&mut self) -> Result<()> {
+    async fn register_new_model(&mut self) -> HandlerResult<()> {
         let (email, password, model_name) = match self.current_msg.take().unwrap() {
             ClientMessage::NewModel {
                 email,
@@ -105,7 +175,7 @@ impl<'a> Handler<'a> {
     }
 
     /// Authenticates a user's challenge response with the API server.
-    async fn authenticate_challenge_response(&mut self) -> Result<()> {
+    async fn authenticate_challenge_response(&mut self) -> HandlerResult<()> {
         let (response, email, model_name) = match self.peek_message().await? {
             ClientMessage::ChallengeResponse {
                 response,
@@ -136,7 +206,7 @@ impl<'a> Handler<'a> {
     }
 
     /// Verifies a user's access token with the API server.
-    async fn verify_access_token(&mut self) -> Result<(String, String)> {
+    async fn verify_access_token(&mut self) -> HandlerResult<(String, String)> {
         let (id, token) = match self.peek_message().await? {
             ClientMessage::AccessToken { id, token } => (id.to_string(), token.to_string()),
             _ => unreachable!(),
@@ -162,7 +232,7 @@ impl<'a> Handler<'a> {
 }
 
 /// Queries the API server and returns the response text.
-pub async fn get_response_text<S: Display + Serialize>(endpoint: &str, body: S) -> Result<String> {
+async fn get_response_text<S: Debug + Serialize>(endpoint: &str, body: S) -> HandlerResult<String> {
     #[cfg(test)]
     let base = mockito::server_url();
 
@@ -171,7 +241,7 @@ pub async fn get_response_text<S: Display + Serialize>(endpoint: &str, body: S) 
 
     let url = format!("{}{}", base, endpoint);
 
-    log::debug!("Sending: {} to {}", &body, &url);
+    log::debug!("Sending: {:?} to {}", &body, &url);
 
     let request = reqwest::Client::new().post(&url).json(&body);
     let response = request.send().await?;
@@ -179,8 +249,10 @@ pub async fn get_response_text<S: Display + Serialize>(endpoint: &str, body: S) 
 
     // Check the status code of the response
     if !status.is_success() {
-        let error = format!("Request to {} failed: {}", url, status);
-        return Err(anyhow!(error));
+        // let error = format!("Request to {} failed: {}", url, status);
+        return Err(HandlerError::Server {
+            code: status.into(),
+        });
     }
 
     let text = response.text().await?;


### PR DESCRIPTION
When users fail authentication through Mallus, send them a nicer error
message describing what happened and how they can likely solve the
problem.