### PR TITLE
fix: deadlock when failing to build clusters

### DIFF
--- a/backend/dcl/src/interface_end/mod.rs
+++ b/backend/dcl/src/interface_end/mod.rs
@@ -138,6 +138,7 @@ async fn process_job(db_conn: Arc<Database>, job_control: JobControl, job: Job) 
         .job_queue
         .push((dataset.project_id, DatasetPair { train, predict }, job));
 
+    log::trace!("Notifying waiters of an incoming job");
     job_control.notify.notify_waiters();
 
     Ok(())

--- a/backend/dcl/src/job_end/mod.rs
+++ b/backend/dcl/src/job_end/mod.rs
@@ -208,7 +208,9 @@ pub async fn run(
         let jq_filter = job_control.job_queue.filter(&nodepool.active);
 
         if jq_filter.is_empty() {
+            log::trace!("No jobs can be completed, waiting on changes");
             job_control.notify.notified().await;
+            log::trace!("Some change has occurred, attempting to complete some jobs");
             continue;
         }
 


### PR DESCRIPTION
Firstly, reset models to not be in use if a cluster fails to be built when flooding the network. This was causing an issue where models would not be considered for jobs if they accepted a previous one that failed to be run.

For example, if a job with 2 models is requested and one accepts and the other rejects, the accepting model would be permanently stuck and would not receive later jobs. This is solved by iterating through and unlocking models if the cluster fails to be built.

This causes a deadlock in the `NodePool::end` function, as the `build_cluster` function still has a lock on the `info` field of the pool.

This can be fixed by calling `drop` on the `RwLockWriteGuard` held by `build_cluster` as soon as the loop finishes, allowing it to be accessed later on if the cluster has failed to be built.
