### PR TITLE
feat: distribute the control layer

### DIFF
--- a/backend/dcl/src/control.rs
+++ b/backend/dcl/src/control.rs
@@ -1,0 +1,210 @@
+//! Contains functions and types for running the control node.
+
+use std::collections::HashSet;
+use std::env;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use anyhow::{anyhow, Result};
+use rand::Rng;
+use tokio::{
+    io::AsyncWriteExt,
+    net::{TcpListener, TcpStream},
+};
+
+use messages::{ControlMessage, ReadLengthPrefix, WriteLengthPrefix};
+
+/// The shared state across control node endpoints.
+type ControlState = Arc<tokio::sync::RwLock<HashSet<u16>>>;
+
+/// Gets the response of a child node and ensures it is correct.
+///
+/// Reads a singular message from the stream and checks that it is equal to the message we sent
+/// previously, returning an error if not.
+async fn get_child_health_response(
+    stream: &mut TcpStream,
+    buffer: &mut [u8],
+    message: &ControlMessage,
+) -> Result<()> {
+    stream.write(&message.as_bytes()).await?;
+    let read_message = ControlMessage::from_stream(stream, buffer).await?;
+
+    // Received a message we didn't expect
+    if read_message != *message {
+        return Err(anyhow!("Child node may be dead"));
+    }
+
+    Ok(())
+}
+
+/// Runs the health checking between the control node and edge nodes.
+///
+/// Simply sends a message every `health_period` seconds and expects the edge node to respond with
+/// the same message back. If it fails 10 times, the connection is over and the node is removed
+/// from the pool.
+async fn run_child_health_checking(
+    port: u16,
+    mut stream: TcpStream,
+    state: ControlState,
+    health_period: u64,
+) -> Result<()> {
+    log::info!("Inserting a child node with port={}", port);
+
+    // Add the port to the state
+    let mut lock = state.write().await;
+    lock.insert(port);
+    drop(lock);
+
+    // Just keep heartbeating with the stream
+    let period = Duration::from_secs(health_period);
+    let mut interval = tokio::time::interval(period);
+
+    // Allocate a buffer for messages we receive
+    let mut buffer = [0_u8; 1024];
+
+    // Count the number of failed heartbeats
+    let mut failed_beats: usize = 0;
+
+    loop {
+        interval.tick().await;
+
+        let timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Send a heartbeat message
+        let message = ControlMessage::Alive { timestamp };
+
+        // Expect to receive the message back before sending the next one
+        let future = get_child_health_response(&mut stream, &mut buffer, &message);
+        let timeout = tokio::time::timeout(period, future).await;
+
+        match timeout {
+            Ok(Err(e)) => {
+                log::warn!("Failed to contact child node: {}", e);
+                failed_beats += 1;
+            }
+            Err(e) => {
+                log::warn!("Child node timed out during health checking: {}", e);
+                failed_beats += 1;
+            }
+            _ => failed_beats = 0,
+        }
+
+        if failed_beats == 10 {
+            break;
+        }
+    }
+
+    // Failed to heartbeat 10 times, assume dead
+    let mut lock = state.write().await;
+    lock.remove(&port);
+
+    Ok(())
+}
+
+/// Responds with an available port for an edge node, if one exists.
+///
+/// `mallus` clients are expected to request an available port and receive a port back to connect
+/// to. This will be one of the available edge nodes that is currently heartbeating.
+async fn answer_port_queries(mut stream: TcpStream, state: ControlState) -> Result<()> {
+    let map = state.read().await;
+
+    // Return a randomly picked port that another node is listening on
+    let port = if map.is_empty() {
+        None
+    } else {
+        let index = rand::thread_rng().gen_range(0..map.len());
+        Some(*map.iter().nth(index).unwrap())
+    };
+
+    // Drop the lock in case sending takes a while
+    drop(map);
+
+    // Send the port back to the client
+    let message = ControlMessage::PortResponse { port };
+    stream.write(&message.as_bytes()).await?;
+
+    Ok(())
+}
+
+/// Handles an incoming TCP stream for the control node.
+///
+/// Reads the first message from the stream to determine the connection type before running the
+/// appropriate handler. Client nodes are expected to request a port to connect to and edge nodes
+/// are expected to register themselves as an edge node and begin heartbeating.
+async fn handle_incoming_stream(
+    port: u16,
+    mut stream: TcpStream,
+    state: ControlState,
+    health_period: u64,
+) -> Result<()> {
+    let mut buffer = [0_u8; 256];
+
+    log::trace!("Attempting to read a message from port={}", port);
+
+    // Read the first message to see how to progress
+    let message = ControlMessage::from_stream(&mut stream, &mut buffer).await?;
+
+    log::debug!(
+        "Received message={:?} from an incoming stream on port={}",
+        message,
+        port
+    );
+
+    match message {
+        ControlMessage::PortRequest => answer_port_queries(stream, Arc::clone(&state)).await?,
+        ControlMessage::ChildNodeRequest { port } => {
+            run_child_health_checking(port, stream, Arc::clone(&state), health_period).await?
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+/// Runs this instance of the DCL as the central control node.
+///
+/// Deals with incoming messages, either from `mallus` clients or other DCL edge nodes wishing to
+/// begin receiving clients.
+pub async fn run_as_controller() -> Result<()> {
+    // Controller nodes bind to the `NODE_SOCKET` environment variable
+    let port = u16::from_str(&env::var("NODE_SOCKET").expect("NODE_SOCKET must be set")).unwrap();
+    let health_period = u64::from_str(&env::var("HEALTH").expect("HEALTH must be set")).unwrap();
+
+    // Create some shared state
+    let state: ControlState = ControlState::default();
+
+    // Bind to the external socket in production mode
+    #[cfg(not(debug_assertions))]
+    let ip = Ipv4Addr::UNSPECIFIED;
+
+    #[cfg(debug_assertions)]
+    let ip = Ipv4Addr::LOCALHOST;
+
+    let socket = SocketAddr::V4(SocketAddrV4::new(ip, port));
+    let listener = TcpListener::bind(&socket).await?;
+
+    log::info!(
+        "Bound to socket={}, waiting for incoming connections to health check every {} seconds",
+        socket,
+        health_period
+    );
+
+    // Process incoming connections
+    while let Ok((stream, addr)) = listener.accept().await {
+        log::debug!("Processing a connection from addr={}", addr);
+
+        let state_clone = Arc::clone(&state);
+
+        // Spawn a new task to handle the request
+        tokio::spawn(async move {
+            handle_incoming_stream(addr.port(), stream, state_clone, health_period).await
+        });
+    }
+
+    Ok(())
+}

--- a/backend/dcl/src/main.rs
+++ b/backend/dcl/src/main.rs
@@ -1,6 +1,9 @@
+use std::env;
+
 use config::Environment;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let filters = vec![
         ("dcl", log::LevelFilter::Debug),
         ("config", log::LevelFilter::Debug),
@@ -19,7 +22,14 @@ fn main() {
 
     config::load(environment);
 
-    if let Err(e) = dcl::run() {
+    // Decide whether to run as the control node or an edge node
+    let result = if env::args().find(|arg| arg == "control").is_some() {
+        dcl::run_as_controller().await
+    } else {
+        dcl::run().await
+    };
+
+    if let Err(e) = result {
         log::error!("Error occurred: {}", e);
     }
 }

--- a/backend/messages/src/client.rs
+++ b/backend/messages/src/client.rs
@@ -5,7 +5,7 @@ use chrono::{Duration, Utc};
 use models::jobs::{JobConfiguration, PredictionType};
 
 /// Different messages to be passed between DCL and DCN
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ClientMessage {
     /// Hearbeat alive message
     Alive {

--- a/backend/messages/src/control.rs
+++ b/backend/messages/src/control.rs
@@ -1,0 +1,23 @@
+//! Contains the messages to be sent between DCL nodes.
+
+/// Messages relating to the distribution of the control layer.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum ControlMessage {
+    /// Request for a port to connect to.
+    PortRequest,
+    /// Request to be a child node in the control layer.
+    ChildNodeRequest {
+        /// The port the node is listening for Mallus connections on.
+        port: u16,
+    },
+    /// Response for a port to connect to.
+    PortResponse {
+        /// The port to connect to.
+        port: Option<u16>,
+    },
+    /// General heartbeating message
+    Alive {
+        /// The current timestamp
+        timestamp: u64,
+    },
+}

--- a/backend/messages/src/lib.rs
+++ b/backend/messages/src/lib.rs
@@ -9,11 +9,13 @@
 extern crate serde;
 
 pub mod client;
+pub mod control;
 pub mod kafka_message;
 pub mod length_prefix;
 pub mod raw_message;
 
 pub use client::ClientMessage;
+pub use control::ControlMessage;
 pub use kafka_message::KafkaWsMessage;
 pub use length_prefix::{ReadLengthPrefix, WriteLengthPrefix};
 pub use raw_message::RawMessage;


### PR DESCRIPTION
Begin the process of distributing the control layer. Running with `cargo run -- control` will begin the control node and otherwise will start a regular edge node as before. Changing to this approach means that you need to run both a control node and an edge node, so this is mostly experimental.

The control node performs 2 functions. Firstly, it will allow edge nodes to connect and begin heartbeating, allowing themselves to be registered as a potential connection point for clients. Secondly, clients from `mallus` can make requests for a port to connect to, which will return a port that an active edge node is connected on.

Clients are thus expected to first query the control node on port 7000 (usually) and then connect normally to the port provided as a response.  Communications from here are as normal and have not changed otherwise.

Edge nodes now need to heartbeat with the control node. This is done through the `health` module and runs alongside the health checking of client nodes.

Some additional messages have been added specific to the `control` portion of the system. This includes messages for heartbeating as normal, but also the edge node registration and port requests, alongside the port responses if one exists.
