### PR TITLE
end node use when not in cluster

### DIFF
--- a/backend/dcl/src/job_end/mod.rs
+++ b/backend/dcl/src/job_end/mod.rs
@@ -653,7 +653,6 @@ pub async fn dcl_protocol(
     }
 
     update_model_statistics(&database, &model_id, processing_time_secs).await?;
-    log::info!("Ending Node {} Connection", model_id);
     nodepool.end(&model_id).await?;
 
     let remaining_nodes = cluster_control.decrement().await;

--- a/backend/dcl/src/node_end/mod.rs
+++ b/backend/dcl/src/node_end/mod.rs
@@ -424,8 +424,6 @@ impl NodePool {
         self.active.fetch_add(1, Ordering::SeqCst);
         self.job_notify.notify_waiters();
 
-        log::info!("Active Nodes: {:?}", self.active);
-
         Ok(())
     }
 


### PR DESCRIPTION
Fix oversight with ending the use of nodes not in built cluster